### PR TITLE
feat(signup): add security questions + update login view

### DIFF
--- a/src/main/java/interface_adapter/signup/SignupController.java
+++ b/src/main/java/interface_adapter/signup/SignupController.java
@@ -1,7 +1,6 @@
 package interface_adapter.signup;
 
-import use_case.signup.SignupInputBoundary;
-import use_case.signup.SignupInputData;
+import use_case.signup.*;
 
 /**
  * Controller for the Signup Use Case.
@@ -10,8 +9,11 @@ public class SignupController {
 
     private final SignupInputBoundary userSignupUseCaseInteractor;
 
-    public SignupController(SignupInputBoundary userSignupUseCaseInteractor) {
+    private final SignupSecurityInputBoundary securityuserSignupUseCaseInteractor;
+    public SignupController(SignupInputBoundary userSignupUseCaseInteractor,
+                            SignupSecurityInputBoundary securityuserSignupUseCaseInteractor) {
         this.userSignupUseCaseInteractor = userSignupUseCaseInteractor;
+        this.securityuserSignupUseCaseInteractor = securityuserSignupUseCaseInteractor;
     }
 
     /**
@@ -20,11 +22,22 @@ public class SignupController {
      * @param password1 the password
      * @param password2 the password repeated
      */
-    public void execute(String username, String password1, String password2) {
-        final SignupInputData signupInputData = new SignupInputData(
-                username, password1, password2);
+    public void execute(String username, String password1, String password2,
+                        String securityQuestion, String securityAnswer) {
 
-        userSignupUseCaseInteractor.execute(signupInputData);
+        if (securityQuestion.isBlank() || securityAnswer.isBlank()) {
+            final SignupInputData signupInputData = new SignupInputData(
+                    username, password1, password2);
+            userSignupUseCaseInteractor.execute(signupInputData);
+
+        } else {
+            final SignupSecurityInputData signupSecurityInputData = new SignupSecurityInputData(
+                    username, password1, password2, securityQuestion, securityAnswer);
+            securityuserSignupUseCaseInteractor.execute(signupSecurityInputData);
+
+        }
+
+
     }
 
     /**

--- a/src/main/java/interface_adapter/signup/SignupState.java
+++ b/src/main/java/interface_adapter/signup/SignupState.java
@@ -10,6 +10,8 @@ public class SignupState {
     private String passwordError;
     private String repeatPassword = "";
     private String repeatPasswordError;
+    private String securityQuestion = "";
+    private String securityAnswer = "";
 
     public String getUsername() {
         return username;
@@ -57,6 +59,22 @@ public class SignupState {
 
     public void setRepeatPasswordError(String repeatPasswordError) {
         this.repeatPasswordError = repeatPasswordError;
+    }
+
+    public String getSecurityQuestion() {
+        return securityQuestion;
+    }
+
+    public String getSecurityAnswer() {
+        return securityAnswer;
+    }
+
+    public void setSecurityQuestion(String securityQuestion) {
+        this.securityQuestion = securityQuestion;
+    }
+
+    public void setSecurityAnswer(String securityAnswer) {
+        this.securityAnswer = securityAnswer;
     }
 
     @Override

--- a/src/main/java/interface_adapter/signup/SignupViewModel.java
+++ b/src/main/java/interface_adapter/signup/SignupViewModel.java
@@ -11,6 +11,8 @@ public class SignupViewModel extends ViewModel<SignupState> {
     public static final String USERNAME_LABEL = "Choose username";
     public static final String PASSWORD_LABEL = "Choose password";
     public static final String REPEAT_PASSWORD_LABEL = "Enter password again";
+    public static final String SECURITY_QUESTION_LABEL = "(Optional) Enter Security Question";
+    public static final String SECURITY_ANSWER_LABEL = "(Optional) Enter Security Answer";
 
     public static final String SIGNUP_BUTTON_LABEL = "Sign up";
     public static final String CANCEL_BUTTON_LABEL = "Cancel";

--- a/src/main/java/use_case/signup/SignupInputData.java
+++ b/src/main/java/use_case/signup/SignupInputData.java
@@ -9,17 +9,20 @@ public class SignupInputData {
     private final String password;
     private final String repeatPassword;
 
-    public SignupInputData(String username, String password, String repeatPassword) {
+    public SignupInputData(String username,
+                           String password,
+                           String repeatPassword
+                           ) {
         this.username = username;
         this.password = password;
         this.repeatPassword = repeatPassword;
     }
 
-    String getUsername() {
+    public String getUsername() {
         return username;
     }
 
-    String getPassword() {
+    public String getPassword() {
         return password;
     }
 

--- a/src/main/java/use_case/signup/SignupSecurityInputBoundary.java
+++ b/src/main/java/use_case/signup/SignupSecurityInputBoundary.java
@@ -1,0 +1,18 @@
+package use_case.signup;
+
+/**
+ * Input Boundary for actions which are related to signing up.
+ */
+public interface SignupSecurityInputBoundary {
+
+    /**
+     * Executes the signup use case.
+     * @param signupInputData the input data
+     */
+    void execute(SignupSecurityInputData signupInputData);
+
+    /**
+     * Executes the switch to login view use case.
+     */
+    void switchToLoginView();
+}

--- a/src/main/java/use_case/signup/SignupSecurityInputData.java
+++ b/src/main/java/use_case/signup/SignupSecurityInputData.java
@@ -1,0 +1,26 @@
+package use_case.signup;
+
+public class SignupSecurityInputData extends SignupInputData {
+
+    private final String securityQuestion;
+    private final String securityAnswer;
+
+    public SignupSecurityInputData(String username,
+                           String password,
+                           String repeatPassword,
+                           String securityQuestion,
+                           String securityAnswer
+    ) {
+        super(username, password, repeatPassword);
+        this.securityQuestion = securityQuestion;
+        this.securityAnswer = securityAnswer;
+    }
+
+    public String getSecurityQuestion() {
+        return securityQuestion;
+    }
+
+    public String getSecurityAnswer() {
+        return securityAnswer;
+    }
+}

--- a/src/main/java/use_case/signup/SignupSecurityInteractor.java
+++ b/src/main/java/use_case/signup/SignupSecurityInteractor.java
@@ -1,0 +1,44 @@
+package use_case.signup;
+
+import entity.User;
+import entity.UserFactory;
+
+/**
+ * The Signup Interactor.
+ */
+public class SignupSecurityInteractor implements SignupSecurityInputBoundary {
+    private final SignupUserDataAccessInterface userDataAccessObject;
+    private final SignupOutputBoundary userPresenter;
+    private final UserFactory userFactory;
+
+    public SignupSecurityInteractor(SignupUserDataAccessInterface signupDataAccessInterface,
+                            SignupOutputBoundary signupOutputBoundary,
+                            UserFactory userFactory) {
+        this.userDataAccessObject = signupDataAccessInterface;
+        this.userPresenter = signupOutputBoundary;
+        this.userFactory = userFactory;
+    }
+
+    @Override
+    public void execute(SignupSecurityInputData signupInputData) {
+        if (userDataAccessObject.existsByName(signupInputData.getUsername())) {
+            userPresenter.prepareFailView("User already exists.");
+        }
+        else if (!signupInputData.getPassword().equals(signupInputData.getRepeatPassword())) {
+            userPresenter.prepareFailView("Passwords don't match.");
+        }
+        else {
+            final User user = userFactory.create(signupInputData.getUsername(), signupInputData.getPassword(),
+                    signupInputData.getSecurityQuestion(), signupInputData.getSecurityAnswer());
+            userDataAccessObject.save(user);
+
+            final SignupOutputData signupOutputData = new SignupOutputData(user.getName(), false);
+            userPresenter.prepareSuccessView(signupOutputData);
+        }
+    }
+
+    @Override
+    public void switchToLoginView() {
+        userPresenter.switchToLoginView();
+    }
+}

--- a/src/main/java/use_case/signup/SignupUserDataAccessInterface.java
+++ b/src/main/java/use_case/signup/SignupUserDataAccessInterface.java
@@ -18,5 +18,6 @@ public interface SignupUserDataAccessInterface {
      * Saves the user.
      * @param user the user to save
      */
+    // TODO: dataaccessobject need to be changed
     void save(User user);
 }

--- a/src/main/java/view/LoginView.java
+++ b/src/main/java/view/LoginView.java
@@ -33,6 +33,7 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
     private final JPasswordField passwordInputField = new JPasswordField(15);
     private final JLabel passwordErrorField = new JLabel();
 
+    private final JButton toSignUp;
     private final JButton logIn;
     private final JButton cancel;
     private LoginController loginController;
@@ -51,10 +52,20 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
                 new JLabel("Password"), passwordInputField);
 
         final JPanel buttons = new JPanel();
+        toSignUp = new JButton("to sign up");
+        buttons.add(toSignUp);
         logIn = new JButton("log in");
         buttons.add(logIn);
         cancel = new JButton("cancel");
         buttons.add(cancel);
+
+        toSignUp.addActionListener(
+                new ActionListener() {
+                    public void actionPerformed(ActionEvent evt) {
+                        loginController.switchToSignUpView();
+                    }
+                }
+        );
 
         logIn.addActionListener(
                 new ActionListener() {
@@ -123,6 +134,8 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
             }
         });
 
+
+
         this.add(title);
         this.add(usernameInfo);
         this.add(usernameErrorField);
@@ -137,6 +150,8 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
     public void actionPerformed(ActionEvent evt) {
         System.out.println("Click " + evt.getActionCommand());
     }
+
+
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {


### PR DESCRIPTION
## Summary
First pass adding security-question capture to the signup flow so we can support future *Forgot Password* recovery.

## Changes
- Add **SignupSecurityInputBoundary**, **SignupSecurityInputData**, **SignupSecurityInteractor** (use_case/signup).
- Extend **SignupUserDataAccessInterface** to persist security Q/A.
- Update **SignupController**, **SignupState**, **SignupViewModel**, **SignupInputData** to include security fields.
- Adjust **LoginView** to prepare for password recovery entry point.
