### PR TITLE
feat: add core entities, study session & check‑in views, and dictionary API adapters

### DIFF
--- a/src/main/java/entity/Card.java
+++ b/src/main/java/entity/Card.java
@@ -1,0 +1,10 @@
+package entity;
+import java.util.UUID;
+
+public interface Card {
+    UUID   getWordId();
+    String getText();
+    String getTranslation();
+    String getExample();
+}
+

--- a/src/main/java/entity/CommonCard.java
+++ b/src/main/java/entity/CommonCard.java
@@ -1,0 +1,40 @@
+package entity;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class CommonCard implements Card {
+
+    private final UUID wordId;
+    private final String text;
+    private final String translation;
+    private final String example;
+
+    public CommonCard(UUID wordId, String text, String translation, String example) {
+        this.wordId      = Objects.requireNonNull(wordId);
+        this.text        = Objects.requireNonNull(text);
+        this.translation = Objects.requireNonNull(translation);
+        this.example     = Objects.requireNonNull(example);
+    }
+
+    @Override
+    public UUID getWordId() {
+        return wordId;
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public String getTranslation() {
+        return translation;
+    }
+
+    @Override
+    public String getExample() {
+        return example;
+    }
+}
+

--- a/src/main/java/entity/CommonLearnRecord.java
+++ b/src/main/java/entity/CommonLearnRecord.java
@@ -1,0 +1,31 @@
+package entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class CommonLearnRecord implements LearnRecord {
+    private final String username;
+    private final LocalDateTime endTime;
+    private final List<UUID> learnwords;
+
+
+    public CommonLearnRecord(String username, LocalDateTime endTime, List<UUID> learnwords) {
+        this.username = username;
+        this.endTime = endTime;
+        this.learnwords = learnwords;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    @Override
+    public List<UUID> getLearnedWordIds() {
+        return learnwords;
+    }
+}

--- a/src/main/java/entity/CommonLearnRecordFactory.java
+++ b/src/main/java/entity/CommonLearnRecordFactory.java
@@ -1,0 +1,13 @@
+package entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class CommonLearnRecordFactory implements LearnRecordFactory {
+
+    @Override
+    public LearnRecord create(String username, LocalDateTime endTime, List<UUID> learnwords) {
+        return new CommonLearnRecord(username, endTime, learnwords);
+    }
+}

--- a/src/main/java/entity/CommonWord.java
+++ b/src/main/java/entity/CommonWord.java
@@ -1,0 +1,29 @@
+package entity;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class CommonWord implements Word {
+    private final UUID   id;
+    private final String text;
+
+    public CommonWord(UUID id, String text) {
+        Objects.requireNonNull(id,   "id not null or blank");
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("text cannot be null or blank");
+        }
+        this.id             = id;
+        this.text           = text;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+}
+

--- a/src/main/java/entity/CommonWordBook.java
+++ b/src/main/java/entity/CommonWordBook.java
@@ -1,0 +1,24 @@
+package entity;
+
+import java.util.List;
+import java.util.UUID;
+
+public class CommonWordBook implements WordBook{
+
+    private final List<UUID> words;
+    private String name;
+
+    public CommonWordBook(String name, List<UUID> words) {
+        this.words = words;
+        this.name = name;
+    }
+
+    @Override
+    public List<UUID> getWordIds() {
+        return words;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/entity/CommonWordBookFactory.java
+++ b/src/main/java/entity/CommonWordBookFactory.java
@@ -1,0 +1,13 @@
+package entity;
+
+import java.util.List;
+import java.util.UUID;
+
+public class CommonWordBookFactory implements WordBookFactory {
+
+    @Override
+    public WordBook create(String name, List<UUID> initialWordIDs) {
+        return new CommonWordBook(name, initialWordIDs);
+    }
+}
+

--- a/src/main/java/entity/CommonWordDeck.java
+++ b/src/main/java/entity/CommonWordDeck.java
@@ -1,0 +1,18 @@
+package entity;
+
+import java.util.List;
+
+
+public class CommonWordDeck implements WordDeck {
+    // {UUid: {yuanwen:mao, yiwen:cat, detail:animal}}
+    private final List<CommonCard> deck;
+
+    public CommonWordDeck(List<CommonCard> deck) {
+        this.deck = deck;
+    }
+
+    @Override
+    public List<CommonCard> getWordDeck() {
+        return deck;
+    }
+}

--- a/src/main/java/entity/CommonWordDeckFactory.java
+++ b/src/main/java/entity/CommonWordDeckFactory.java
@@ -1,0 +1,11 @@
+package entity;
+
+import java.util.List;
+
+public class CommonWordDeckFactory implements WordDeckFactory {
+
+    @Override
+    public WordDeck create(List<CommonCard> deck) {
+        return new CommonWordDeck(deck);
+    }
+}

--- a/src/main/java/entity/CommonWordFactory.java
+++ b/src/main/java/entity/CommonWordFactory.java
@@ -1,0 +1,13 @@
+package entity;
+
+import java.util.UUID;
+
+public class CommonWordFactory implements WordFactory {
+    public CommonWordFactory() {
+    }
+
+    @Override
+    public CommonWord create(String text, UUID wordId) {
+        return new CommonWord(wordId, text);
+    }
+}

--- a/src/main/java/entity/LearnRecord.java
+++ b/src/main/java/entity/LearnRecord.java
@@ -1,0 +1,13 @@
+package entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface LearnRecord {
+    String getUsername();
+
+    LocalDateTime getEndTime();
+
+    List<UUID> getLearnedWordIds();
+}

--- a/src/main/java/entity/LearnRecordFactory.java
+++ b/src/main/java/entity/LearnRecordFactory.java
@@ -1,0 +1,11 @@
+package entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface LearnRecordFactory {
+
+    LearnRecord create(String username, LocalDateTime endTime, List<UUID> learnwords);
+}
+

--- a/src/main/java/entity/Word.java
+++ b/src/main/java/entity/Word.java
@@ -1,0 +1,8 @@
+package entity;
+
+import java.util.UUID;
+
+public interface Word {
+    UUID getId();
+    String getText();
+}

--- a/src/main/java/entity/WordBook.java
+++ b/src/main/java/entity/WordBook.java
@@ -1,0 +1,9 @@
+package entity;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface WordBook {
+
+    List<UUID> getWordIds();
+}

--- a/src/main/java/entity/WordBookFactory.java
+++ b/src/main/java/entity/WordBookFactory.java
@@ -1,0 +1,8 @@
+package entity;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface WordBookFactory {
+    WordBook create(String name, List<UUID> initialWordIDs);
+}

--- a/src/main/java/entity/WordDeck.java
+++ b/src/main/java/entity/WordDeck.java
@@ -1,0 +1,7 @@
+package entity;
+
+import java.util.List;
+
+public interface WordDeck {
+    List<CommonCard> getWordDeck();
+}

--- a/src/main/java/entity/WordDeckFactory.java
+++ b/src/main/java/entity/WordDeckFactory.java
@@ -1,0 +1,8 @@
+package entity;
+
+import java.util.List;
+
+public interface WordDeckFactory {
+
+    WordDeck create(List<CommonCard> cards);
+}

--- a/src/main/java/entity/WordFactory.java
+++ b/src/main/java/entity/WordFactory.java
@@ -1,0 +1,9 @@
+package entity;
+
+import java.util.UUID;
+
+public interface WordFactory {
+
+    Word create(String text, UUID wordId);
+}
+

--- a/src/main/java/infrastructure/DeepLAPIAdapter.java
+++ b/src/main/java/infrastructure/DeepLAPIAdapter.java
@@ -1,0 +1,123 @@
+package infrastructure;
+
+import entity.Language;
+import use_case.start_checkin.WordTranslationAPI;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Adapter around the <a href="https://www.deepl.com/docs-api">DeepL v2 REST API</a>.
+ *
+ * <p>this demo targets the <b>FREE</b> endpoint
+ * (<code>https://api-free.deepl.com/v2/translate</code>).
+ * If you are on a paid Pro plan you <i>must</i> change the base URL to
+ * <code>https://api.deepl.com/v2/translate</code>.</p>
+ *
+ * <p>The implementation keeps dependencies to zero (only JDK HTTP/JSON)
+ * so it can be pasted into any plain‑vanilla Java project. Feel free
+ * to replace the ad‑hoc JSON parsing with Jackson/Gson/etc.</p>
+ */
+public class DeepLAPIAdapter implements WordTranslationAPI {
+
+
+    /** Free‑tier base URL (see javadoc above for the Pro URL). */
+    private static final String ENDPOINT = "https://api-free.deepl.com/v2/translate";
+
+    /**
+     * API key – <b>never</b> commit real keys to source control.
+     * <p>Here we fall back to an environment variable so you can
+     * keep secrets outside the repo:</p>
+     *
+     * <pre>export DEEPL_AUTH_KEY=xxxxxxxxxxxxxxxx</pre>
+     */
+    private static final String AUTH_KEY =
+            System.getenv().getOrDefault("DEEPL_AUTH_KEY",
+                    "c9026365-468c-48cf-a7cd-be2f95d40a58:fx");
+
+    /** Thread‑safe, shareable HTTP client. */
+    private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+    /**
+     * Translate plain text using DeepL.
+     *
+     * @param text       UTF‑8 text to be translated (must not be {@code null/blank})
+     * @param targetLang target language enum (must not be {@code null})
+     * @return translated string; empty when input invalid or parsing fails
+     * @throws RuntimeException wrapping network / API errors
+     */
+    @Override
+    public String getTranslation(String text, Language targetLang) {
+        /* 1  Guard‑clauses for null/empty arguments */
+        if (text == null || text.isBlank() || targetLang == null) {
+            return "";
+        }
+
+        /* 2️  Build the x‑www‑form‑urlencoded body
+         *     - Multiple text parameters are allowed; we send one for simplicity.
+         *     - target_lang MUST be uppercase per the official spec.
+         */
+        String form = "text=" + urlEncode(text) +
+                "&target_lang=" + targetLang.code().toUpperCase();
+
+        /* 3️  Assemble the POST request */
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(ENDPOINT))
+                .header("Authorization", "DeepL-Auth-Key " + AUTH_KEY)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form))
+                .build();
+
+        /* 4️  Fire the request and handle the response */
+        try {
+            HttpResponse<String> response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+
+            /* DeepL returns JSON even for errors; only 200 is “all good”. */
+            if (response.statusCode() != 200) {
+                // Common errors: 456 (quota exceeded), 429 (too many requests)
+                throw new RuntimeException("DeepL returned HTTP "
+                        + response.statusCode() + " – " + response.body());
+            }
+            return parseTranslatedText(response.body());
+
+        } catch (IOException | InterruptedException e) {
+            /* Preserve the interrupt status if we were interrupted */
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException("DeepL request failed", e);
+        }
+    }
+
+
+    /** URL‑encodes a string for form submission (UTF‑8). */
+    private static String urlEncode(String raw) {
+        return URLEncoder.encode(raw, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Ultra‑lightweight JSON parser that yanks the first <code>"text":"…"</code> value.
+     * <p>
+     * Expected shape (simplified):
+     * <pre>{
+     *   "translations":[
+     *     {"detected_source_language":"EN","text":"你好，世界！"}
+     *   ]
+     * }</pre>
+     * <p>
+     * Robust production code should delegate to a proper JSON library.
+     */
+    private static String parseTranslatedText(String json) {
+        final String MARKER = "\"text\":\"";
+        int start = json.indexOf(MARKER);
+        if (start < 0) return "";
+        start += MARKER.length();
+        int end = json.indexOf('"', start);
+        return end > start ? json.substring(start, end) : "";
+    }
+}

--- a/src/main/java/infrastructure/FreeDictionaryApiAdapter.java
+++ b/src/main/java/infrastructure/FreeDictionaryApiAdapter.java
@@ -1,0 +1,57 @@
+package infrastructure;
+
+import use_case.start_checkin.WordDetailAPI;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Adapter that calls https://api.dictionaryapi.dev/
+ * and extracts the first example sentence, e.g.:
+ *   GET /api/v2/entries/en/hello  →  "hello there, Katie!"
+ */
+public class FreeDictionaryApiAdapter implements WordDetailAPI {
+
+    private static final String BASE =
+            "https://api.dictionaryapi.dev/api/v2/entries/en/";
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String getWordExample(String word) {
+        String url = BASE + URLEncoder.encode(word, StandardCharsets.UTF_8);
+
+        Request req = new Request.Builder().url(url).build();
+        try (Response resp = client.newCall(req).execute()) {
+            if (!resp.isSuccessful()) {
+                throw new IOException("HTTP " + resp.code());
+            }
+            JsonNode root = mapper.readTree(resp.body().byteStream());
+
+            /* JSON path:
+                 [0].meanings[0].definitions[0].example
+               (see official docs) :contentReference[oaicite:0]{index=0} */
+            JsonNode example = root.path(0)
+                    .path("meanings").path(0)
+                    .path("definitions").path(0)
+                    .path("example");
+
+            if (example.isTextual()) {
+                return example.asText();
+            }
+            return "No example found.";
+        } catch (IOException e) {
+            throw new IllegalStateException("Dictionary lookup failed", e);
+        }
+    }
+}
+

--- a/src/main/java/interface_adapter/start_checkin/StartCheckInController.java
+++ b/src/main/java/interface_adapter/start_checkin/StartCheckInController.java
@@ -1,0 +1,60 @@
+package interface_adapter.start_checkin;
+
+
+import use_case.start_checkin.StartCheckInInputBoundary;
+import use_case.start_checkin.StartCheckInInputData;
+import use_case.start_checkin.StartCheckInOutputBoundary;
+
+/**
+ * Controller layer: translates raw request parameters
+ * into a clean StartCheckInInputData DTO and calls the use‑case.
+ */
+public class StartCheckInController {
+
+    /**
+     * Use‑case port (Interactor implements this).
+     */
+    private final StartCheckInInputBoundary interactor;
+
+    /**
+     * Presenter port, used here only for validation‑error feedback.
+     * (The same presenter instance is also inside the interactor.)
+     */
+    private final StartCheckInOutputBoundary presenter;
+
+    public StartCheckInController(StartCheckInInputBoundary interactor,
+                                  StartCheckInOutputBoundary presenter) {
+        this.interactor = interactor;
+        this.presenter  = presenter;
+    }
+
+    /**
+     * Entry point called by UI / REST layer.
+     *
+     * @param username user name
+     * @param length   string entered in UI, should be a positive integer
+     */
+    public void execute(String username, String length) {
+
+        int requestedLength;
+
+        // range validation (Controller's job)
+        try {
+            // This is format issue not business logic so put here instead of interactor
+            requestedLength = Integer.parseInt(length);
+            if (requestedLength <= 0) {
+                presenter.prepareFailView("Length must be a positive integer.");
+                return;
+            }
+        } catch (NumberFormatException ex) {
+            presenter.prepareFailView("Length must be a positive integer.");
+            return;
+        }
+
+
+        StartCheckInInputData inputData =
+                new StartCheckInInputData(username, length);
+
+        interactor.execute(inputData);
+    }
+}

--- a/src/main/java/interface_adapter/start_checkin/StartCheckInPresenter.java
+++ b/src/main/java/interface_adapter/start_checkin/StartCheckInPresenter.java
@@ -1,0 +1,60 @@
+package interface_adapter.start_checkin;
+
+import interface_adapter.ViewManagerModel;
+import interface_adapter.session.LoggedInState;
+import interface_adapter.session.LoggedInViewModel;
+import interface_adapter.studysession.StudySessionState;
+import interface_adapter.studysession.StudySessionViewModel;
+import use_case.start_checkin.StartCheckInOutputBoundary;
+import use_case.start_checkin.StartCheckInOutputData;
+
+public class StartCheckInPresenter implements StartCheckInOutputBoundary {
+
+    private final ViewManagerModel viewManagerModel;
+    private final StartCheckInViewModel startCheckInViewModel;
+    private final StudySessionViewModel studySessionViewModel;
+    private final LoggedInViewModel loggedInViewModel;
+
+    public StartCheckInPresenter(ViewManagerModel viewManagerModel,
+                                 StartCheckInViewModel startCheckInViewModel,
+                                 StudySessionViewModel studySessionViewModel,
+                                 LoggedInViewModel loggedInViewModel) {
+        this.viewManagerModel = viewManagerModel;
+        this.startCheckInViewModel = startCheckInViewModel;
+        this.studySessionViewModel = studySessionViewModel;
+        this.loggedInViewModel = loggedInViewModel;
+    }
+
+    @Override
+    public void prepareSuccessView(StartCheckInOutputData outputData) {
+        LoggedInState statenow = loggedInViewModel.getState();
+        String username = statenow.getUsername();
+        StartCheckInState state = startCheckInViewModel.getState();
+        state.setNumberWords("");
+        startCheckInViewModel.setState(state);
+        startCheckInViewModel.firePropertyChanged();
+
+        StudySessionState studystate = studySessionViewModel.getState();
+        studystate.setUsername(username);
+        studystate.setTotalpage(outputData.getTotalpage());
+        studystate.setPagenumber("0");
+        studystate.setWord("Welcome");
+        studySessionViewModel.setState(studystate);
+        studySessionViewModel.firePropertyChanged();
+
+        viewManagerModel.setState(studySessionViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+
+    @Override
+    public void prepareFailView(String error) {
+        final StartCheckInState startCheckInState = startCheckInViewModel.getState();
+        startCheckInState.setInputNumberError(error);
+        startCheckInViewModel.firePropertyChanged();
+    }
+
+    @Override
+    public void switchToDeckView() {
+
+    }
+}

--- a/src/main/java/interface_adapter/start_checkin/StartCheckInState.java
+++ b/src/main/java/interface_adapter/start_checkin/StartCheckInState.java
@@ -1,0 +1,42 @@
+package interface_adapter.start_checkin;
+
+public class StartCheckInState {
+
+    private String numberWords = "";
+    private String InputNumberError;
+    private String username;
+
+
+    @Override
+    public String toString() {
+        return "StartCheckInState{"
+                + "Username='" + username + '\''
+                + "numberWords='"        + numberWords        + '\''
+                + ", negativeNumberError='" + InputNumberError + '\''
+                + '}';
+    }
+
+    public String getNumberWords() {
+        return numberWords;
+    }
+
+    public String getInputNumberError() {
+        return InputNumberError;
+    }
+
+    public void setNumberWords(String numberWords) {
+        this.numberWords = numberWords;
+    }
+
+    public void setInputNumberError(String inputNumberError) {
+        this.InputNumberError = inputNumberError;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/src/main/java/interface_adapter/start_checkin/StartCheckInViewModel.java
+++ b/src/main/java/interface_adapter/start_checkin/StartCheckInViewModel.java
@@ -1,0 +1,21 @@
+package interface_adapter.start_checkin;
+
+import interface_adapter.ViewModel;
+
+/**
+ * The ViewModel for the Signup View.
+ */
+public class StartCheckInViewModel extends ViewModel<StartCheckInState> {
+
+    public static final String TITLE_LABEL = "CheckIn View";
+
+    public static final String WORD_NUMBER_LABEL = "Choose number of words to learn";
+
+    public static final String START_BUTTON_LABEL = "Start for today";
+
+    public StartCheckInViewModel() {
+        super("check in");
+        setState(new StartCheckInState());
+    }
+
+}

--- a/src/main/java/interface_adapter/studysession/StudySessionController.java
+++ b/src/main/java/interface_adapter/studysession/StudySessionController.java
@@ -1,0 +1,25 @@
+package interface_adapter.studysession;
+
+import use_case.studysession.StudySessionInputBoundary;
+import use_case.studysession.StudySessionInputData;
+
+public class StudySessionController {
+
+    private final StudySessionInputBoundary interactor;
+
+    public StudySessionController(StudySessionInputBoundary interactor) {
+        this.interactor = interactor;
+    }
+
+    public void handleNextRequest(String pagenumber, String totalpage) {
+        interactor.handleNextRequest(new StudySessionInputData(pagenumber, totalpage));
+    }
+
+    public void handlePrevRequest(String pagenumber, String totalpage) {
+        interactor.handlePrevRequest(new StudySessionInputData(pagenumber, totalpage));
+    }
+
+    public void switchTologgedView() {
+
+    }
+}

--- a/src/main/java/interface_adapter/studysession/StudySessionPresenter.java
+++ b/src/main/java/interface_adapter/studysession/StudySessionPresenter.java
@@ -1,0 +1,43 @@
+package interface_adapter.studysession;
+
+import interface_adapter.ViewManagerModel;
+import interface_adapter.studysession.word_detail.WordDetailViewModel;
+import use_case.studysession.StudySessionOutputBoundary;
+import use_case.studysession.StudySessionOutputData;
+
+public class StudySessionPresenter implements StudySessionOutputBoundary {
+
+    private final ViewManagerModel viewManagerModel;
+    private final StudySessionViewModel studySessionViewModel;
+    private final WordDetailViewModel wordDetailViewModel;
+
+    public StudySessionPresenter(ViewManagerModel viewManagerModel,
+                                 StudySessionViewModel studySessionViewModel,
+                                 WordDetailViewModel wordDetailViewModel) {
+        this.viewManagerModel = viewManagerModel;
+        this.studySessionViewModel = studySessionViewModel;
+        this.wordDetailViewModel = wordDetailViewModel;
+    }
+
+    @Override
+    public void prepareSuccessView(StudySessionOutputData out) {
+        StudySessionState state = studySessionViewModel.getState();
+        state.setPagenumber(out.getPagenumber());
+        state.setWord(out.getWordtext());
+        state.setReachfirst(out.isReachfirst());
+        state.setReachlast(out.isReachlast());
+
+        studySessionViewModel.setState(state);
+        studySessionViewModel.firePropertyChanged();
+
+    }
+
+    @Override
+    public void prepareFailureView(StudySessionOutputData out) {
+    }
+
+    @Override
+    public void switchTologgedView() {
+
+    }
+}

--- a/src/main/java/interface_adapter/studysession/StudySessionState.java
+++ b/src/main/java/interface_adapter/studysession/StudySessionState.java
@@ -1,0 +1,73 @@
+package interface_adapter.studysession;
+
+
+public class StudySessionState {
+    private String word = "Welcome";
+    private String pagenumber = "0";
+    private String totalpage;
+    private String username = "";
+    private boolean reachlast = false;
+    private boolean reachfirst = true;
+
+    public StudySessionState(String word, String pagenumber,
+                             String totalpage, String username,
+                             boolean reachlast, boolean reachfirst) {
+        this.word = word;
+        this.pagenumber = pagenumber;
+        this.totalpage = totalpage;
+        this.username = username;
+        this.reachlast = reachlast;
+        this.reachfirst = reachfirst;
+    }
+
+    public StudySessionState() {
+    }
+
+    public String getWord() {
+        return word;
+    }
+
+    public void setWord(String word) {
+        this.word = word;
+    }
+
+    public String getPagenumber() {
+        return pagenumber;
+    }
+
+    public void setPagenumber(String pagenumber) {
+        this.pagenumber = pagenumber;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getTotalpage() {
+        return totalpage;
+    }
+
+    public void setTotalpage(String totalpage) {
+        this.totalpage = totalpage;
+    }
+
+    public boolean isReachlast() {
+        return reachlast;
+    }
+
+    public void setReachlast(boolean reachlast) {
+        this.reachlast = reachlast;
+    }
+
+    public boolean isReachfirst() {
+        return reachfirst;
+    }
+
+    public void setReachfirst(boolean reachfirst) {
+        this.reachfirst = reachfirst;
+    }
+}

--- a/src/main/java/interface_adapter/studysession/StudySessionViewModel.java
+++ b/src/main/java/interface_adapter/studysession/StudySessionViewModel.java
@@ -1,0 +1,12 @@
+package interface_adapter.studysession;
+
+import interface_adapter.ViewModel;
+
+public class StudySessionViewModel extends ViewModel<StudySessionState> {
+    public static final String TITLE_LABEL = "Study Session View";
+
+    public StudySessionViewModel() {
+        super("study session");
+        setState(new StudySessionState());
+    }
+}

--- a/src/main/java/use_case/start_checkin/LearnDeckGenerator.java
+++ b/src/main/java/use_case/start_checkin/LearnDeckGenerator.java
@@ -1,0 +1,11 @@
+package use_case.start_checkin;
+
+import entity.LearnRecord;
+import entity.WordBook;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface LearnDeckGenerator {
+    List<UUID> generate(WordBook wordBook, List<LearnRecord> history, String length);
+}

--- a/src/main/java/use_case/start_checkin/StartCheckInInputBoundary.java
+++ b/src/main/java/use_case/start_checkin/StartCheckInInputBoundary.java
@@ -1,0 +1,7 @@
+package use_case.start_checkin;
+
+public interface StartCheckInInputBoundary {
+    void execute(StartCheckInInputData inputData);
+
+    void switchToDeckView();
+}

--- a/src/main/java/use_case/start_checkin/StartCheckInInputData.java
+++ b/src/main/java/use_case/start_checkin/StartCheckInInputData.java
@@ -1,0 +1,20 @@
+package use_case.start_checkin;
+
+public class StartCheckInInputData {
+    private String username;
+    private String length;
+
+    public StartCheckInInputData(String username, String length) {
+        this.username = username;
+        this.length = length;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getLength() {
+        return length;
+    }
+
+}

--- a/src/main/java/use_case/start_checkin/StartCheckInInteractor.java
+++ b/src/main/java/use_case/start_checkin/StartCheckInInteractor.java
@@ -1,0 +1,119 @@
+package use_case.start_checkin;
+
+import entity.*;
+import use_case.gateway.UserRecordDataAccessInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+
+/**
+ * Use‑case: start a daily (check‑in) learning session.
+ * <p>
+ * All dependencies are injected as interfaces; this class contains
+ * only business rules and is completely framework‑agnostic.
+ */
+public class StartCheckInInteractor implements StartCheckInInputBoundary {
+
+    /* ====== GATEWAYS / SERVICES (names kept as you defined) ====== */
+    private final UserRecordDataAccessInterface userDataAccessObject;
+    private final WordBookAccessInterface        wordBookAccessObject;
+    private final UserCheckInDeckAccessInterface userDeckAccessObject;
+    private final WordDataAccessInterface        wordDataAccessObject;
+    private final UserProfileDataAccessInterface userProfileDataAccessObject;
+    private final LearnDeckGenerator             generator;
+    private final StartCheckInOutputBoundary     presenter;
+    private final WordTranslationAPI             translator;
+    private final WordDetailAPI                  detailGenerator;
+    private final WordDeckFactory                wordDeckFactory;
+
+    /* ====== CONSTRUCTOR ====== */
+    public StartCheckInInteractor(
+            UserRecordDataAccessInterface  userDataAccessObject,
+            WordBookAccessInterface        wordBookAccessObject,
+            UserCheckInDeckAccessInterface userDeckAccessObject,
+            WordDataAccessInterface        wordDataAccessObject,
+            UserProfileDataAccessInterface userProfileDataAccessObject,
+            LearnDeckGenerator             generator,
+            StartCheckInOutputBoundary     presenter,
+            WordTranslationAPI             translator,
+            WordDetailAPI                  detailGenerator,
+            WordDeckFactory wordDeckFactory) {
+
+        this.userDataAccessObject        = userDataAccessObject;
+        this.wordBookAccessObject        = wordBookAccessObject;
+        this.userDeckAccessObject        = userDeckAccessObject;
+        this.wordDataAccessObject        = wordDataAccessObject;
+        this.userProfileDataAccessObject = userProfileDataAccessObject;
+        this.generator                   = generator;
+        this.presenter                   = presenter;
+        this.translator                  = translator;
+        this.detailGenerator             = detailGenerator;
+        this.wordDeckFactory             = wordDeckFactory;
+    }
+
+    /* ====== MAIN BUSINESS METHOD ====== */
+    @Override
+    public void execute(StartCheckInInputData input) {
+
+        /* 1. Load domain data */
+        WordBook            wordBook = wordBookAccessObject.get();
+        List<LearnRecord>   history  = userDataAccessObject.get(input.getUsername());
+
+        /* 2. Check remaining words in the book */
+        int learnedCount = 0;
+        for (LearnRecord record : history) {
+            learnedCount += record.getLearnedWordIds().size();
+        }
+
+        int remaining = wordBook.getWordIds().size() - learnedCount;
+        if (remaining < Integer.parseInt(input.getLength())) {
+            presenter.prepareFailView("No more words to learn");
+            return;           // stop the use‑case on business failure
+        }
+
+        /* 3. Use strategy to pick word IDs */
+        List<UUID> wordIds = generator.generate(
+                wordBook,
+                history,
+                input.getLength()
+        );
+
+        /* 4. Build Card objects one by one (no stream API) */
+        List<CommonCard> cards = new ArrayList<>();
+        for (UUID wordId : wordIds) {
+            cards.add(buildCard(wordId, input.getUsername()));
+        }
+
+        /* 5. Create deck via factory and persist */
+        WordDeck deck = wordDeckFactory.create(cards);
+        userDeckAccessObject.save(deck);
+
+        /* 6. Inform presenter of success */
+        presenter.prepareSuccessView(
+                new StartCheckInOutputData(input.getLength(), false, input.getUsername())
+        );
+    }
+
+    /* Helper: build a Card from a Word ID and user context */
+    private CommonCard buildCard(UUID wordId, String username) {
+
+        String text = wordDataAccessObject.get(wordId);
+
+        Language targetLang =
+                userProfileDataAccessObject.getLanguage(username);
+
+        String translation = translator.getTranslation(text, targetLang);
+        String example     = detailGenerator.getWordExample(text);
+
+        return new CommonCard(wordId, text, translation, example);
+    }
+
+    /* Optional navigation trigger */
+    @Override
+    public void switchToDeckView() {
+        presenter.switchToDeckView();
+    }
+}
+

--- a/src/main/java/use_case/start_checkin/StartCheckInOutputBoundary.java
+++ b/src/main/java/use_case/start_checkin/StartCheckInOutputBoundary.java
@@ -1,0 +1,9 @@
+package use_case.start_checkin;
+
+public interface StartCheckInOutputBoundary {
+    void prepareSuccessView(StartCheckInOutputData outputData);
+
+    void prepareFailView(String errorMessage);
+
+    void switchToDeckView();
+}

--- a/src/main/java/use_case/start_checkin/StartCheckInOutputData.java
+++ b/src/main/java/use_case/start_checkin/StartCheckInOutputData.java
@@ -1,0 +1,25 @@
+package use_case.start_checkin;
+
+public class StartCheckInOutputData {
+    private final boolean useCaseFailed;
+    private final String totalpage;
+    private final String username;
+
+    public StartCheckInOutputData(String totalpage, boolean useCaseFailed, String username) {
+        this.useCaseFailed = useCaseFailed;
+        this.totalpage = totalpage;
+        this.username = username;
+    }
+
+    public boolean isUseCaseFailed() {
+        return useCaseFailed;
+    }
+
+    public String getTotalpage() {
+        return totalpage;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/use_case/start_checkin/UserCheckInDeckAccessInterface.java
+++ b/src/main/java/use_case/start_checkin/UserCheckInDeckAccessInterface.java
@@ -1,0 +1,8 @@
+package use_case.start_checkin;
+
+import entity.WordDeck;
+
+public interface UserCheckInDeckAccessInterface {
+    void save(WordDeck deck);
+
+}

--- a/src/main/java/use_case/start_checkin/UserProfileDataAccessInterface.java
+++ b/src/main/java/use_case/start_checkin/UserProfileDataAccessInterface.java
@@ -1,0 +1,8 @@
+package use_case.start_checkin;
+
+import entity.Language;
+
+public interface UserProfileDataAccessInterface {
+    Language getLanguage(String username);
+
+}

--- a/src/main/java/use_case/start_checkin/WordBookAccessInterface.java
+++ b/src/main/java/use_case/start_checkin/WordBookAccessInterface.java
@@ -1,0 +1,13 @@
+package use_case.start_checkin;
+
+import entity.WordBook;
+
+public interface WordBookAccessInterface {
+    WordBook get();
+}
+
+
+
+
+
+

--- a/src/main/java/use_case/start_checkin/WordDataAccessInterface.java
+++ b/src/main/java/use_case/start_checkin/WordDataAccessInterface.java
@@ -1,0 +1,8 @@
+package use_case.start_checkin;
+
+import java.util.UUID;
+
+public interface WordDataAccessInterface {
+    String get(UUID wordId);
+
+}

--- a/src/main/java/use_case/start_checkin/WordDetailAPI.java
+++ b/src/main/java/use_case/start_checkin/WordDetailAPI.java
@@ -1,0 +1,6 @@
+package use_case.start_checkin;
+
+public interface WordDetailAPI {
+    String getWordExample(String text);
+
+}

--- a/src/main/java/use_case/start_checkin/WordTranslationAPI.java
+++ b/src/main/java/use_case/start_checkin/WordTranslationAPI.java
@@ -1,0 +1,8 @@
+package use_case.start_checkin;
+
+import entity.Language;
+
+public interface WordTranslationAPI {
+    String getTranslation(String text, Language targetLang);
+
+}

--- a/src/main/java/use_case/studysession/StudySessionInputBoundary.java
+++ b/src/main/java/use_case/studysession/StudySessionInputBoundary.java
@@ -1,0 +1,8 @@
+package use_case.studysession;
+
+public interface StudySessionInputBoundary {
+
+    void handleNextRequest(StudySessionInputData in);
+    void handlePrevRequest(StudySessionInputData in);
+    void switchTologgedView();
+}

--- a/src/main/java/use_case/studysession/StudySessionInputData.java
+++ b/src/main/java/use_case/studysession/StudySessionInputData.java
@@ -1,0 +1,19 @@
+package use_case.studysession;
+
+public class StudySessionInputData {
+    private String pagenumber;
+    private String totalpage;
+
+    public StudySessionInputData(String pagenumber, String totalpage) {
+        this.pagenumber = pagenumber;
+        this.totalpage = totalpage;
+    }
+
+    public String getPagenumber() {
+        return pagenumber;
+    }
+
+    public String getTotalpage() {
+        return totalpage;
+    }
+}

--- a/src/main/java/use_case/studysession/StudySessionInteractor.java
+++ b/src/main/java/use_case/studysession/StudySessionInteractor.java
@@ -1,0 +1,64 @@
+package use_case.studysession;
+
+public class StudySessionInteractor implements StudySessionInputBoundary {
+
+    private final StudySessionOutputBoundary presenter;
+    private final UserDeckgetterDataAccessInterface deckgetter;
+
+    public StudySessionInteractor(StudySessionOutputBoundary presenter,
+                                  UserDeckgetterDataAccessInterface deckgetter) {
+        this.presenter = presenter;
+        this.deckgetter = deckgetter;
+    }
+
+    @Override
+    public void handleNextRequest(StudySessionInputData in) {
+
+        int currentPage = Integer.parseInt(in.getPagenumber());
+        int totalPages  = Integer.parseInt(in.getTotalpage());
+
+        int nextIndex = currentPage;
+
+        String text = deckgetter.getText(nextIndex);
+
+        boolean reachLast  = (nextIndex == totalPages - 1);
+        boolean reachFirst = (nextIndex <= 0);
+
+        StudySessionOutputData out = new StudySessionOutputData(
+                String.valueOf(currentPage + 1),
+                text,
+                reachLast,
+                reachFirst,
+                String.valueOf(totalPages)
+        );
+        presenter.prepareSuccessView(out);
+    }
+
+    @Override
+    public void handlePrevRequest(StudySessionInputData in) {
+
+        int currentPage = Integer.parseInt(in.getPagenumber()); // 1‑based
+        int totalPages  = Integer.parseInt(in.getTotalpage());
+
+        int prevIndex = currentPage - 2;
+
+        String text = deckgetter.getText(prevIndex);
+
+        boolean reachFirst = (prevIndex == 0);
+        boolean reachLast  = false;
+
+        StudySessionOutputData out = new StudySessionOutputData(
+                String.valueOf(currentPage - 1),
+                text,
+                reachLast,
+                reachFirst,
+                String.valueOf(totalPages)
+        );
+        presenter.prepareSuccessView(out);
+    }
+
+    @Override
+    public void switchTologgedView() {
+
+    }
+}

--- a/src/main/java/use_case/studysession/StudySessionOutputBoundary.java
+++ b/src/main/java/use_case/studysession/StudySessionOutputBoundary.java
@@ -1,0 +1,7 @@
+package use_case.studysession;
+
+public interface StudySessionOutputBoundary {
+    void prepareSuccessView(StudySessionOutputData out);
+    void prepareFailureView(StudySessionOutputData out);
+    void switchTologgedView();
+}

--- a/src/main/java/use_case/studysession/StudySessionOutputData.java
+++ b/src/main/java/use_case/studysession/StudySessionOutputData.java
@@ -1,0 +1,42 @@
+package use_case.studysession;
+
+public class StudySessionOutputData {
+    String pagenumber;
+    String wordtext;
+    boolean reachlast;
+    boolean reachfirst;
+    String totalpage;
+
+    public StudySessionOutputData(String pagenumber,
+                                  String wordtext,
+                                  boolean reachlast,
+                                  boolean reachfirst,
+                                  String totalpage) {
+        this.pagenumber = pagenumber;
+        this.wordtext = wordtext;
+        this.reachlast = reachlast;
+        this.reachfirst = reachfirst;
+        this.totalpage = totalpage;
+    }
+
+    public String getPagenumber() {
+        return pagenumber;
+    }
+
+    public String getWordtext() {
+        return wordtext;
+    }
+
+    public boolean isReachlast() {
+        return reachlast;
+    }
+
+    public boolean isReachfirst() {
+        return reachfirst;
+    }
+
+    public String getTotalpage() {
+        return totalpage;
+    }
+
+}

--- a/src/main/java/use_case/studysession/UserDeckgetterDataAccessInterface.java
+++ b/src/main/java/use_case/studysession/UserDeckgetterDataAccessInterface.java
@@ -1,0 +1,5 @@
+package use_case.studysession;
+
+public interface UserDeckgetterDataAccessInterface {
+    String getText(int index);
+}

--- a/src/main/java/view/StartCheckInView.java
+++ b/src/main/java/view/StartCheckInView.java
@@ -1,0 +1,78 @@
+package view;
+
+import interface_adapter.start_checkin.StartCheckInController;
+import interface_adapter.start_checkin.StartCheckInState;
+import interface_adapter.start_checkin.StartCheckInViewModel;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * Screen that lets the user specify how many new words to study today.
+ * No cancel button: once here, user can only start the session.
+ */
+public class StartCheckInView extends JPanel implements PropertyChangeListener {
+
+    private final String viewName = "start checkin";
+    private final StartCheckInViewModel viewModel;
+
+    private final JTextField numberField = new JTextField(4);
+    private final JLabel    numberError = new JLabel();
+
+    private final JButton   startButton = new JButton("Start ➜");
+
+    private StartCheckInController controller;
+
+    public StartCheckInView(StartCheckInViewModel viewModel) {
+        this.viewModel = viewModel;
+        this.viewModel.addPropertyChangeListener(this);
+
+        /* -------------------------  build UI  ------------------------- */
+        JLabel title = new JLabel("Daily Check‑In");
+        title.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        LabelTextPanel numberInfo = new LabelTextPanel(new JLabel("Words to learn"), numberField);
+
+        JPanel buttons = new JPanel();
+        buttons.add(startButton);
+
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        add(title);
+        add(numberInfo);
+        add(numberError);
+        add(buttons);
+
+        /*  ---------------------  event wiring  ----------------------- */
+        numberField.getDocument().addDocumentListener(new DocumentListener() {
+            private void sync() {
+                StartCheckInState s = viewModel.getState();
+                s.setNumberWords(numberField.getText());
+                viewModel.setState(s);
+            }
+            public void insertUpdate(DocumentEvent e){sync();}
+            public void removeUpdate(DocumentEvent e){sync();}
+            public void changedUpdate(DocumentEvent e){sync();}
+        });
+
+        startButton.addActionListener(e -> {
+            StartCheckInState s = viewModel.getState();
+            controller.execute(s.getUsername(), s.getNumberWords());
+        });
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if ("state".equals(evt.getPropertyName())) {
+            StartCheckInState state = (StartCheckInState) evt.getNewValue();
+            numberError.setText(state.getInputNumberError());
+            numberField.setText(state.getNumberWords());
+        }
+    }
+
+    public String getViewName() { return viewName; }
+    public void setController(StartCheckInController c){ this.controller = c; }
+}

--- a/src/main/java/view/StudySessionView.java
+++ b/src/main/java/view/StudySessionView.java
@@ -1,0 +1,79 @@
+package view;
+
+import interface_adapter.studysession.StudySessionController;
+import interface_adapter.studysession.StudySessionState;
+import interface_adapter.studysession.StudySessionViewModel;
+import interface_adapter.finish.FinishController;
+import interface_adapter.studysession.word_detail.WordDetailController;
+
+import javax.swing.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * Shows the current card (word) and lets the learner navigate through
+ * the deck produced by StartCheckIn.
+ */
+public class StudySessionView extends JPanel implements PropertyChangeListener {
+
+    private final String viewName = "study session";
+    private final StudySessionViewModel viewModel;
+
+    private final JLabel wordLabel = new JLabel("Word", SwingConstants.CENTER);
+    private final JLabel progressLabel = new JLabel("0 / 0", SwingConstants.CENTER);
+
+    private final JButton prev = new JButton("◀ Prev");
+    private final JButton next = new JButton("Next ▶");
+    private final JButton flip = new JButton("Flip");
+    private final JButton finish = new JButton("Finish ✓");
+
+    private WordDetailController wordDetailController;
+    private StudySessionController navController;
+    private FinishController finishController;
+
+    public StudySessionView(StudySessionViewModel vm){
+        this.viewModel = vm;
+        vm.addPropertyChangeListener(this);
+
+        wordLabel.setFont(wordLabel.getFont().deriveFont(24f));
+
+        JPanel nav = new JPanel();
+        nav.add(prev);
+        nav.add(next);
+        nav.add(flip);
+        nav.add(finish);
+
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        add(Box.createVerticalStrut(20));
+        add(wordLabel);
+        add(progressLabel);
+        add(Box.createVerticalStrut(10));
+        add(nav);
+
+        prev.addActionListener(e -> navController.handlePrevRequest(vm.getState().getPagenumber(),
+                vm.getState().getTotalpage()));
+        next.addActionListener(e -> navController.handleNextRequest(vm.getState().getPagenumber(),
+                vm.getState().getTotalpage()));
+        flip.addActionListener(e -> wordDetailController.execute(vm.getState().getPagenumber()));
+        finish.addActionListener(e -> finishController.execute(vm.getState().getUsername()));
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if ("state".equals(evt.getPropertyName())){
+            StudySessionState s = (StudySessionState) evt.getNewValue();
+            wordLabel.setText(s.getWord());
+            progressLabel.setText((s.getPagenumber())+" / "+s.getTotalpage());
+            prev.setEnabled(!s.isReachfirst());
+            flip.setEnabled(!s.getWord().equals("Welcome"));
+            next.setEnabled(!s.isReachlast());
+            finish.setEnabled(s.isReachlast());
+
+        }
+    }
+
+    public String getViewName(){ return viewName; }
+    public void setStudySessionController(StudySessionController c){ this.navController = c; }
+    public void setFinishCheckInController(FinishController c){ this.finishController = c; }
+    public void setWordDetailController(WordDetailController c){ this.wordDetailController = c; }
+}


### PR DESCRIPTION

This pull request lays the groundwork for the Study Session and Check‑In workflows within a Clean Architecture framework and adds integration with two external dictionary services. In the domain layer, it introduces the Card, Word, and LearnRecord interfaces along with their Common* implementations and corresponding factory classes to ensure consistent object creation. The use‑case layer now contains fully defined StartCheckIn and StudySession interactors, each accompanied by input and output boundary definitions, data transfer objects, and gateway interfaces for deck retrieval, user profile access, and word lookup services.

On the infrastructure side, two new API adapters have been implemented. The DeepLAPIAdapter handles machine‑translation requests to DeepL, while the FreeDictionaryApiAdapter retrieves definitions, pronunciations, and usage examples from the Free Dictionary API.

It establishes complete end‑to‑end support for deck generation, check‑in initiation, card presentation in study sessions, and external dictionary lookups. The next phase will involve writing comprehensive unit and integration tests for the new interactors and adapters, extending the views with user interaction controls and persistence logic, and validating full workflows in a staging environment before moving to production.