### PR TITLE
feat: JSON / In‑Memory DAOs + “Rank” & “Word Detail” features, UI wiring, and build‑time assembly

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -1,41 +1,101 @@
 package app;
 
 import java.awt.CardLayout;
+import java.io.IOException;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 
-import data_access.InMemoryUserDataAccessObject;
-import entity.CommonUserFactory;
-import entity.SecurityUserFactory;
-import entity.UserFactory;
+import data_access.*;
+import data_access.JsonUserProfileDAO;
+import entity.*;
+import infrastructure.DeepLAPIAdapter;
+import infrastructure.FreeDictionaryApiAdapter;
+import infrastructure.LearnWordsGenerator;
+import infrastructure.TimeGenerator;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.achievement.AchievementController;
+import interface_adapter.achievement.AchievementPresenter;
+import interface_adapter.achievement.AchievementViewModel;
 import interface_adapter.change_password.ChangePasswordController;
 import interface_adapter.change_password.ChangePasswordPresenter;
-import interface_adapter.change_password.LoggedInViewModel;
+import interface_adapter.change_password.ChangeViewModel;
+import interface_adapter.change_password.MakePasswordChange.MakePasswordChangeController;
+import interface_adapter.change_password.MakePasswordChange.MakePasswordChangePresenter;
+import interface_adapter.profile.ProfileController;
+import interface_adapter.profile.ProfilePresenter;
+import interface_adapter.profile.ProfileViewModel;
+import interface_adapter.profile.profile_set.ProfileSetController;
+import interface_adapter.profile.profile_set.ProfileSetPresenter;
+import interface_adapter.session.LoggedInViewModel;
+import interface_adapter.finish.FinishController;
+import interface_adapter.finish.FinishPresenter;
 import interface_adapter.login.LoginController;
 import interface_adapter.login.LoginPresenter;
 import interface_adapter.login.LoginViewModel;
 import interface_adapter.logout.LogoutController;
 import interface_adapter.logout.LogoutPresenter;
+import interface_adapter.rank.RankController;
+import interface_adapter.rank.RankPresenter;
+import interface_adapter.rank.RankViewModel;
 import interface_adapter.signup.SignupController;
 import interface_adapter.signup.SignupPresenter;
 import interface_adapter.signup.SignupViewModel;
+import interface_adapter.start_checkin.StartCheckInController;
+import interface_adapter.start_checkin.StartCheckInPresenter;
+import interface_adapter.start_checkin.StartCheckInViewModel;
+import interface_adapter.studysession.StudySessionController;
+import interface_adapter.studysession.StudySessionPresenter;
+import interface_adapter.studysession.StudySessionViewModel;
+import interface_adapter.studysession.word_detail.WordDetailController;
+import interface_adapter.studysession.word_detail.WordDetailPresenter;
+import interface_adapter.studysession.word_detail.WordDetailViewModel;
+import interface_adapter.view_history.ViewHistoryController;
+import interface_adapter.view_history.ViewHistoryPresenter;
+import interface_adapter.view_history.ViewHistoryViewModel;
+import use_case.achievement.AchievementInputBoundary;
+import use_case.achievement.AchievementInteractor;
+import use_case.achievement.AchievementOutputBoundary;
 import use_case.change_password.ChangePasswordInputBoundary;
 import use_case.change_password.ChangePasswordInteractor;
 import use_case.change_password.ChangePasswordOutputBoundary;
+import use_case.change_password.make_password_change.MakePasswordChangeInputBoundary;
+import use_case.change_password.make_password_change.MakePasswordChangeInteractor;
+import use_case.change_password.make_password_change.MakePasswordChangeOutputBoundary;
+import use_case.finish_checkin.FinishCheckInInputBoundary;
+import use_case.finish_checkin.FinishCheckInInteractor;
+import use_case.finish_checkin.FinishCheckInOutputBoundary;
+import use_case.finish_checkin.TimeGetter;
 import use_case.login.LoginInputBoundary;
 import use_case.login.LoginInteractor;
 import use_case.login.LoginOutputBoundary;
 import use_case.logout.LogoutInputBoundary;
 import use_case.logout.LogoutInteractor;
 import use_case.logout.LogoutOutputBoundary;
+import use_case.profile.ProfileInputBoundary;
+import use_case.profile.ProfileInteractor;
+import use_case.profile.ProfileOutputBoundary;
+import use_case.profile.profile_set.ProfileSetInputBoundary;
+import use_case.profile.profile_set.ProfileSetInteractor;
+import use_case.profile.profile_set.ProfileSetOutputBoundary;
+import use_case.rank.RankInputBoundary;
+import use_case.rank.RankInteractor;
+import use_case.rank.RankOutputBoundary;
 import use_case.signup.*;
-import view.LoggedInView;
-import view.LoginView;
-import view.SignupView;
-import view.ViewManager;
+import use_case.start_checkin.StartCheckInInputBoundary;
+import use_case.start_checkin.StartCheckInInteractor;
+import use_case.start_checkin.StartCheckInOutputBoundary;
+import use_case.studysession.StudySessionInputBoundary;
+import use_case.studysession.StudySessionInteractor;
+import use_case.studysession.StudySessionOutputBoundary;
+import use_case.studysession.word_detail.WordDetailInputBoundary;
+import use_case.studysession.word_detail.WordDetailInteractor;
+import use_case.studysession.word_detail.WordDetailOutputBoundary;
+import use_case.viewhistory.ViewHistoryInputBoundary;
+import use_case.viewhistory.ViewHistoryInteractor;
+import use_case.viewhistory.ViewHistoryOutputBoundary;
+import view.*;
 
 /**
  * The AppBuilder class is responsible for putting together the pieces of
@@ -52,23 +112,54 @@ public class AppBuilder {
     private final JPanel cardPanel = new JPanel();
     private final CardLayout cardLayout = new CardLayout();
     // thought question: is the hard dependency below a problem?
-    private final UserFactory userFactory = new CommonUserFactory();
-    private final UserFactory securityUserFactory = new SecurityUserFactory();
+    private final WordDeckFactory wordDeckFactory = new CommonWordDeckFactory();
+    private final LearnRecordFactory learnRecordFactory = new CommonLearnRecordFactory();
+    private final ProfileFactory profileFactory = new PersonalProfileFactory();
+
+
     private final ViewManagerModel viewManagerModel = new ViewManagerModel();
     private final ViewManager viewManager = new ViewManager(cardPanel, cardLayout, viewManagerModel);
 
     // thought question: is the hard dependency below a problem?
     // private final DBUserDataAccessObject userDataAccessObject = new DBUserDataAccessObject(userFactory);
-    private final InMemoryUserDataAccessObject userDataAccessObject = new InMemoryUserDataAccessObject();
+    // private final InMemoryUserDataAccessObject userDataAccessObject = new InMemoryUserDataAccessObject();
+    private final JsonUserDataAccessObject userDataAccessObject = new JsonUserDataAccessObject();
+    private final InMemoryDeckDataAccessObejct deckDataAccessObject = new InMemoryDeckDataAccessObejct();
+    private final JsonUserRecordDataAccessObject userRecordDataAccessObject = new JsonUserRecordDataAccessObject();
+    private final WordBookDataAccessObject wordBookDataAccessObject = new WordBookDataAccessObject();
+    private final WordDataAccessObject wordDataAccessObject = new WordDataAccessObject();
+    private final JsonUserProfileDAO userProfileDAO = new JsonUserProfileDAO();
 
     private SignupView signupView;
+    private WordDetailView wordDetailView;
     private SignupViewModel signupViewModel;
     private LoginViewModel loginViewModel;
     private LoggedInViewModel loggedInViewModel;
     private LoggedInView loggedInView;
     private LoginView loginView;
+    private StudySessionView studySessionView;
+    private StartCheckInViewModel startCheckInViewModel;
+    private StartCheckInView startCheckInView;
+    private StudySessionViewModel studySessionViewModel;
+    private WordDetailViewModel wordDetailViewModel;
+    private RankView rankView;
+    private RankViewModel rankViewModel;
+    private AchievementView achievementView;
+    private AchievementViewModel achievementViewModel;
+    private ViewHistoryView viewHistoryView;
+    private ViewHistoryViewModel viewHistoryViewModel;
+    private ProfileView profileView;
+    private ProfileViewModel profileViewModel;
+    private ChangePasswordView changePasswordView;
+    private ChangeViewModel changeViewModel;
 
-    public AppBuilder() {
+    private final DeepLAPIAdapter deepLapi = new DeepLAPIAdapter();
+    private final FreeDictionaryApiAdapter freeDictionaryApi = new FreeDictionaryApiAdapter();
+    private final LearnWordsGenerator learnWordsGenerator = new LearnWordsGenerator();
+    private final TimeGetter timegetter = new TimeGenerator();
+
+
+    public AppBuilder() throws IOException {
         cardPanel.setLayout(cardLayout);
     }
 
@@ -101,19 +192,134 @@ public class AppBuilder {
     public AppBuilder addLoggedInView() {
         loggedInViewModel = new LoggedInViewModel();
         loggedInView = new LoggedInView(loggedInViewModel);
+
+        startCheckInViewModel = new StartCheckInViewModel();
+        startCheckInView = new StartCheckInView(startCheckInViewModel);
+        loggedInView.addStartCheckInPage(startCheckInView);
+
+        profileViewModel = new ProfileViewModel();
+        final ProfileSetOutputBoundary profileSetPresenter = new ProfileSetPresenter(profileViewModel);
+        final ProfileSetInputBoundary profileSetInteractor = new ProfileSetInteractor(userProfileDAO, profileSetPresenter, profileFactory);
+        final ProfileSetController profileSetController = new ProfileSetController(profileSetInteractor);
+
+        final ProfileOutputBoundary profilePresenter = new ProfilePresenter(profileViewModel);
+        final ProfileInputBoundary profileInteractor = new ProfileInteractor(profilePresenter, userProfileDAO);
+        final ProfileController profileController = new ProfileController(profileInteractor);
+        profileView = new ProfileView(profileViewModel, profileSetController);
+
+        loggedInView.addProfilePage(profileView);
+        loggedInView.setProfileController(profileController);
+
+        changeViewModel = new ChangeViewModel();
+        final ChangePasswordOutputBoundary changePasswordPresenter = new ChangePasswordPresenter(changeViewModel);
+        final ChangePasswordInputBoundary changePasswordInteractor = new ChangePasswordInteractor(
+                changePasswordPresenter, userDataAccessObject);
+        final ChangePasswordController changePasswordController = new ChangePasswordController(changePasswordInteractor);
+        changePasswordView = new ChangePasswordView(changeViewModel);
+        final MakePasswordChangeOutputBoundary  presenter = new MakePasswordChangePresenter(changeViewModel);
+        final MakePasswordChangeInputBoundary interactor = new MakePasswordChangeInteractor(presenter, userDataAccessObject, BuiltInUserFactory.COMMON, BuiltInUserFactory.SECURITY);
+        final MakePasswordChangeController controller = new MakePasswordChangeController(interactor);
+        changePasswordView.setController(controller);
+
+        loggedInView.addChangePasswordPage(changePasswordView);
+        loggedInView.setChangePasswordController(changePasswordController);
+
+        viewHistoryViewModel = new ViewHistoryViewModel();
+        final ViewHistoryOutputBoundary viewHistoryPresenter =
+                new ViewHistoryPresenter(viewHistoryViewModel);
+        //TODO modify dataaccessobject
+        final ViewHistoryInputBoundary viewHistoryInteractor =
+                new ViewHistoryInteractor(userRecordDataAccessObject, viewHistoryPresenter);
+        final ViewHistoryController viewHistoryController =
+                new ViewHistoryController(viewHistoryInteractor);
+        viewHistoryView = new ViewHistoryView(viewHistoryViewModel);
+
+        loggedInView.addViewHistoryPage(viewHistoryView);
+        loggedInView.setViewHistoryController(viewHistoryController);
+
+        rankViewModel = new RankViewModel();
+        final RankOutputBoundary rankPresenter = new RankPresenter(rankViewModel);
+        final RankInputBoundary rankInteractor = new RankInteractor(userRecordDataAccessObject, rankPresenter);
+        final RankController rankController = new RankController(rankInteractor);
+        rankView = new RankView(rankViewModel, rankController);
+
+        loggedInView.addRankPage(rankView);
+        loggedInView.setRankController(rankController);
+
+        achievementViewModel = new AchievementViewModel();
+        final AchievementOutputBoundary achievementPresenter = new AchievementPresenter(achievementViewModel);
+        final AchievementInputBoundary achievementInteractor = new AchievementInteractor(achievementPresenter, userRecordDataAccessObject);
+        final AchievementController achievementController = new AchievementController(achievementInteractor);
+        achievementView = new AchievementView(achievementViewModel);
+
+
+        loggedInView.addAchievementPage(achievementView);
+        loggedInView.setAchievementController(achievementController);
+
         cardPanel.add(loggedInView, loggedInView.getViewName());
         return this;
     }
+
+    public AppBuilder addStudySessionView() {
+        studySessionViewModel = new StudySessionViewModel();
+        studySessionView = new StudySessionView(studySessionViewModel);
+
+        cardPanel.add(studySessionView, studySessionView.getViewName());
+        return this;
+    }
+
+    public AppBuilder addWordDetailView() {
+        wordDetailViewModel = new WordDetailViewModel();
+        wordDetailView = new WordDetailView(wordDetailViewModel);
+
+        cardPanel.add(wordDetailView, wordDetailView.getViewName());
+        return this;
+    }
+
+    public AppBuilder addFinishCheckInUseCase() {
+        final FinishCheckInOutputBoundary presenter = new FinishPresenter(loggedInViewModel,
+                viewManagerModel, studySessionViewModel);
+        final FinishCheckInInputBoundary interactor = new FinishCheckInInteractor(presenter,
+                userRecordDataAccessObject, deckDataAccessObject, learnRecordFactory, timegetter);
+        final FinishController controller = new FinishController(interactor);
+        studySessionView.setFinishCheckInController(controller);
+        return this;
+    }
+
+    public AppBuilder addStudySessionUseCase() {
+        final StudySessionOutputBoundary presenter = new StudySessionPresenter(viewManagerModel,
+                studySessionViewModel,
+                wordDetailViewModel);
+        final StudySessionInputBoundary interactor = new StudySessionInteractor(presenter, deckDataAccessObject);
+        final StudySessionController controller = new StudySessionController(interactor);
+        studySessionView.setStudySessionController(controller);
+        return this;
+    }
+
+    public AppBuilder addStartCheckInUseCase() {
+        final StartCheckInOutputBoundary presenter = new StartCheckInPresenter(viewManagerModel,
+                startCheckInViewModel, studySessionViewModel, loggedInViewModel);
+        final StartCheckInInputBoundary interactor
+                = new StartCheckInInteractor(userRecordDataAccessObject,
+                wordBookDataAccessObject, deckDataAccessObject, wordDataAccessObject, userProfileDAO,
+                learnWordsGenerator, presenter, deepLapi, freeDictionaryApi, wordDeckFactory);
+        final StartCheckInController controller = new StartCheckInController(interactor, presenter);
+        startCheckInView.setController(controller);
+        return this;
+    }
+
 
     /**
      * Adds the Signup Use Case to the application.
      * @return this builder
      */
     public AppBuilder addSignupUseCase() {
+        UserFactory commonUserFactory   = BuiltInUserFactory.COMMON;
+        UserFactory securityUserFactory = BuiltInUserFactory.SECURITY;
         final SignupOutputBoundary signupOutputBoundary = new SignupPresenter(viewManagerModel,
                 signupViewModel, loginViewModel);
         final SignupInputBoundary userSignupInteractor = new SignupInteractor(
-                userDataAccessObject, signupOutputBoundary, userFactory);
+                userDataAccessObject, signupOutputBoundary, commonUserFactory);
 
         final SignupSecurityInputBoundary securityuserSignupInteractor =
                 new SignupSecurityInteractor(userDataAccessObject, signupOutputBoundary, securityUserFactory);
@@ -122,35 +328,20 @@ public class AppBuilder {
         return this;
     }
 
+
+
     /**
      * Adds the Login Use Case to the application.
      * @return this builder
      */
     public AppBuilder addLoginUseCase() {
         final LoginOutputBoundary loginOutputBoundary = new LoginPresenter(viewManagerModel,
-                loggedInViewModel, loginViewModel, signupViewModel);
+                loggedInViewModel, loginViewModel, signupViewModel, startCheckInViewModel);
         final LoginInputBoundary loginInteractor = new LoginInteractor(
                 userDataAccessObject, loginOutputBoundary);
 
         final LoginController loginController = new LoginController(loginInteractor);
         loginView.setLoginController(loginController);
-        return this;
-    }
-
-    /**
-     * Adds the Change Password Use Case to the application.
-     * @return this builder
-     */
-    public AppBuilder addChangePasswordUseCase() {
-        final ChangePasswordOutputBoundary changePasswordOutputBoundary =
-                new ChangePasswordPresenter(loggedInViewModel);
-
-        final ChangePasswordInputBoundary changePasswordInteractor =
-                new ChangePasswordInteractor(userDataAccessObject, changePasswordOutputBoundary, userFactory);
-
-        final ChangePasswordController changePasswordController =
-                new ChangePasswordController(changePasswordInteractor);
-        loggedInView.setChangePasswordController(changePasswordController);
         return this;
     }
 
@@ -167,6 +358,17 @@ public class AppBuilder {
 
         final LogoutController logoutController = new LogoutController(logoutInteractor);
         loggedInView.setLogoutController(logoutController);
+        return this;
+    }
+
+    public AppBuilder addWordDetaiUsecase() {
+        final WordDetailOutputBoundary presenter = new WordDetailPresenter(
+                viewManagerModel, wordDetailViewModel, studySessionViewModel);
+        final WordDetailInputBoundary interactor =
+                new WordDetailInteractor(presenter, deckDataAccessObject);
+        final WordDetailController controller = new WordDetailController(interactor);
+        wordDetailView.setWordDetailController(controller);
+        studySessionView.setWordDetailController(controller);
         return this;
     }
 

--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -1,10 +1,12 @@
 package app;
 
-import javax.swing.JFrame;
+import javax.swing.*;
 
 import com.formdev.flatlaf.FlatDarkLaf;      // You can also use FlatDarkLaf
-import javax.swing.*;
+
 import java.awt.*;
+import java.io.IOException;
+
 
 /**
  * Application entry point: sets up FlatLaf and then builds the CA architecture.
@@ -12,14 +14,12 @@ import java.awt.*;
 public class Main {
 
     public static void main(String[] args) {
-        /* ---------- 1. Set up global Look-and-Feel ---------- */
 
         FlatDarkLaf.setup();                             // Use the light theme
         // On Linux/Mac, to enable FlatLaf's custom window decorations:
         JFrame.setDefaultLookAndFeelDecorated(true);      // Use FlatLaf decorations for JFrame
         JDialog.setDefaultLookAndFeelDecorated(true);     // Use FlatLaf decorations for JDialog
 
-        /* ---------- 2. Optional UI defaults ---------- */
         UIManager.put("Component.focusColor", new Color(0x007AFF));
         UIManager.put( "Button.arc", 999 );
         UIManager.put( "Component.arc", 999 );
@@ -31,21 +31,33 @@ public class Main {
         UIManager.put("TextComponent.background", new Color(250, 250, 250));
         UIManager.put("Button.innerFocusWidth", 2);
 
-        /* ---------- 3. Build and display the main window on the EDT ---------- */
         SwingUtilities.invokeLater(() -> {
-            JFrame application = new AppBuilder()
-                    .addLoginView()
-                    .addSignupView()
-                    .addLoggedInView()
-                    .addSignupUseCase()
-                    .addLoginUseCase()
-                    .addChangePasswordUseCase()
-                    .addLogoutUseCase()
-                    .build();
+            JFrame application = null;
+            try {
+                application = new AppBuilder()
+                        .addSignupView()
+                        .addLoginView()
+
+                        .addLoggedInView()
+                        .addStudySessionView()
+                        .addWordDetailView()
+
+                        .addSignupUseCase()
+                        .addLoginUseCase()
+                        .addLogoutUseCase()
+
+                        .addStartCheckInUseCase()
+                        .addStudySessionUseCase()
+                        .addWordDetaiUsecase()
+                        .addFinishCheckInUseCase()
+                        .build();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
 
             application.pack();
-
-            application.setSize(437, 270); // Center the window
+            application.setSize(469,290);
+            // application.setSize(437, 270);
             application.setLocationRelativeTo(null);
             application.setVisible(true);
 

--- a/src/main/java/data_access/InMemoryDeckDataAccessObejct.java
+++ b/src/main/java/data_access/InMemoryDeckDataAccessObejct.java
@@ -1,0 +1,56 @@
+package data_access;
+
+import entity.CommonCard;
+import entity.WordDeck;
+import use_case.finish_checkin.UserDeckGetTextDataAccessInterface;
+import use_case.start_checkin.UserCheckInDeckAccessInterface;
+import use_case.studysession.UserDeckgetterDataAccessInterface;
+import use_case.studysession.word_detail.WordDetailDataAccessInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InMemoryDeckDataAccessObejct implements UserDeckGetTextDataAccessInterface,
+        UserCheckInDeckAccessInterface,
+        UserDeckgetterDataAccessInterface,
+        WordDetailDataAccessInterface {
+
+    private List<CommonCard> cardList = new ArrayList<>();
+
+    @Override
+    public List<CommonCard> getWordDeck() {
+        return cardList;
+    }
+
+    @Override
+    public void save(WordDeck deck) {
+        cardList = deck.getWordDeck();
+    }
+
+    @Override
+    public String getText(int index) {
+        return getTextHelper(index);
+    }
+
+    private String getTextHelper(int index) {
+        return cardList.get(index).getText();
+    }
+
+    @Override
+    public String getTranslation(int i) {
+        return getTranslationHelper(i);
+    }
+
+    private String getTranslationHelper(int i) {
+        return cardList.get(i).getTranslation();
+    }
+
+    @Override
+    public String getExample(int i) {
+        return getExampleHelper(i);
+    }
+
+    private String getExampleHelper(int i) {
+        return cardList.get(i).getExample();
+    }
+}

--- a/src/main/java/data_access/JsonUserDataAccessObject.java
+++ b/src/main/java/data_access/JsonUserDataAccessObject.java
@@ -1,0 +1,132 @@
+package data_access;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import entity.CommonUser;
+import entity.SecurityUser;
+import entity.User;
+import use_case.change_password.ChangePasswordUserTypeDataAccessInterface;
+import use_case.change_password.make_password_change.UserPasswordDataAccessInterface;
+import use_case.login.LoginUserDataAccessInterface;
+import use_case.logout.LogoutUserDataAccessInterface;
+import use_case.signup.SignupUserDataAccessInterface;
+
+import java.io.*;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Single‑file JSON storage for all user objects.
+ */
+public final class JsonUserDataAccessObject implements
+        SignupUserDataAccessInterface,
+        LoginUserDataAccessInterface,
+        LogoutUserDataAccessInterface,
+        ChangePasswordUserTypeDataAccessInterface,
+        UserPasswordDataAccessInterface {
+
+    private static final String FILE_PATH = "resources\\data\\users.json";
+    private static final Gson   GSON      = new GsonBuilder().setPrettyPrinting().create();
+
+    private final File                    store  = new File(FILE_PATH);
+    private final Map<String, User>       users  = new HashMap<>();
+    private       String                  currentUsername;
+
+    public JsonUserDataAccessObject() throws IOException {
+        File parent = store.getParentFile();
+        if (!parent.exists() && !parent.mkdirs()) {
+            throw new IOException("Cannot create data dir: " + parent);
+        }
+        if (store.exists()) {
+            load();
+        } else if (!store.createNewFile()) {
+            throw new IOException("Cannot create " + FILE_PATH);
+        }
+    }
+
+    @Override
+    public String getType(String username) {
+        User u = users.get(username);
+        if (u == null) return null;
+        return (u instanceof SecurityUser) ? "SECURITY" : "COMMON";
+    }
+
+    @Override
+    public String getSecurityQuestion(String username) {
+        User u = users.get(username);
+        if (u instanceof SecurityUser) {
+            return ((SecurityUser) u).getSecurityQuestion();
+        }
+        return null;
+    }
+
+    @Override
+    public void update(String username, User updatedUser) {
+        if (username == null || updatedUser == null) {
+            throw new IllegalArgumentException("username / user == null");
+        }
+        users.put(username, updatedUser);
+        persist();
+    }
+
+    @Override
+    public String getAnswer(String username) {
+        User u = users.get(username);
+        if (u instanceof SecurityUser) {
+            return ((SecurityUser) u).getSecurityAnswer();
+        }
+        return null;
+    }
+
+    @Override
+    public String getQuestion(String username) {
+        User u = users.get(username);
+        if (u instanceof SecurityUser) {
+            return ((SecurityUser) u).getSecurityQuestion();
+        }
+        return null;
+    }
+
+    @Override public boolean existsByName(String id)         { return users.containsKey(id); }
+    @Override public void    save(User user)                 { users.put(user.getName(), user); persist(); }
+    @Override public User    get(String username)            { return users.get(username); }
+    @Override public void    setCurrentUsername(String name) { this.currentUsername = name; }
+    @Override public String  getCurrentUsername()            { return currentUsername; }
+
+    public Map<String, User> snapshot() { return Collections.unmodifiableMap(users); }
+
+    private void load() throws IOException {
+        if (store.length() == 0) return;
+        try (Reader r = new BufferedReader(new FileReader(store))) {
+            JsonObject root = JsonParser.parseReader(r).getAsJsonObject();
+            for (Map.Entry<String, JsonElement> e : root.entrySet()) {
+                JsonObject obj  = e.getValue().getAsJsonObject();
+                String     type = obj.get("type").getAsString();
+                User u = switch (type) {
+                    case "COMMON"   -> GSON.fromJson(obj, CommonUser.class);
+                    case "SECURITY" -> GSON.fromJson(obj, SecurityUser.class);
+                    default         -> throw new IllegalStateException("Unknown user type: " + type);
+                };
+                users.put(e.getKey(), u);
+            }
+        }
+    }
+
+    private void persist() {
+        try (Writer w = new BufferedWriter(new FileWriter(store, false))) {
+            Map<String, JsonObject> toWrite = new HashMap<>();
+            for (Map.Entry<String, User> e : users.entrySet()) {
+                JsonObject obj = (JsonObject) GSON.toJsonTree(e.getValue());
+                obj.addProperty("type", (e.getValue() instanceof SecurityUser) ? "SECURITY" : "COMMON");
+                toWrite.put(e.getKey(), obj);
+            }
+            Type mapType = new TypeToken<Map<String, JsonObject>>() {}.getType();
+            GSON.toJson(toWrite, mapType, w);
+        } catch (IOException ioe) {
+            throw new RuntimeException("Failed to write user DB", ioe);
+        }
+    }
+}
+

--- a/src/main/java/data_access/JsonUserProfileDAO.java
+++ b/src/main/java/data_access/JsonUserProfileDAO.java
@@ -1,0 +1,115 @@
+package data_access;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import entity.Language;
+import entity.PersonalProfile;
+import use_case.profile.ProfileUserDataAccessInterface;
+import use_case.profile.profile_set.ProfileSetUserDataAccessInterface;
+import use_case.start_checkin.UserProfileDataAccessInterface;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JSON‑based DAO that stores **all** user profiles in a single file <b>profiles.json</b>,
+ * mapping <code>username → PersonalProfile</code>.
+ * <p>
+ * Implements:
+ * <ul>
+ *   <li>{@link ProfileSetUserDataAccessInterface} – save / update profile</li>
+ *   <li>{@link UserProfileDataAccessInterface} – query language by username</li>
+ *   <li>{@link ProfileUserDataAccessInterface} – other profile‑read needs</li>
+ * </ul>
+ */
+public class JsonUserProfileDAO implements ProfileSetUserDataAccessInterface,
+        UserProfileDataAccessInterface,
+        ProfileUserDataAccessInterface {
+
+    /** Default directory on Windows; can be overridden via ctor. */
+    private static final String DEFAULT_DIR =
+            "resources\\data";
+
+    private static final String FILE_NAME = "profiles.json";
+
+    private final Path filePath;          // …/profiles.json
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private final Type mapType = new TypeToken<Map<String, PersonalProfile>>(){}.getType();
+
+    public JsonUserProfileDAO() {
+        this(DEFAULT_DIR);
+    }
+
+    public JsonUserProfileDAO(String dirPath) {
+        Path dir = Paths.get(dirPath);
+        ensureDirectoryExists(dir);
+        this.filePath = dir.resolve(FILE_NAME);
+        ensureFileExists();
+    }
+
+    @Override
+    public synchronized void save(PersonalProfile personalProfile) {
+        if (personalProfile == null) throw new IllegalArgumentException("profile == null");
+        Map<String, PersonalProfile> map = readAll();
+        map.put(personalProfile.getUsername(), personalProfile);
+        writeAll(map);
+    }
+
+    @Override
+    public synchronized Language getLanguage(String username) {
+        PersonalProfile p = readAll().get(username);
+        return p != null ? p.getLanguage() : null;
+    }
+
+    public synchronized void updateLanguage(String username, Language newLanguage) {
+        if (username == null || newLanguage == null) throw new IllegalArgumentException("username / language is null");
+        Map<String, PersonalProfile> map = readAll();
+        PersonalProfile updated = new PersonalProfile(username, newLanguage);
+        map.put(username, updated);
+        writeAll(map);
+    }
+
+    private void ensureDirectoryExists(Path dir) {
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create data directory: " + dir, e);
+        }
+    }
+
+    private void ensureFileExists() {
+        try {
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, "{}", StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create profile json: " + filePath, e);
+        }
+    }
+
+    private Map<String, PersonalProfile> readAll() {
+        try {
+            String json = Files.readString(filePath, StandardCharsets.UTF_8);
+            Map<String, PersonalProfile> map = gson.fromJson(json, mapType);
+            return map != null ? map : new HashMap<>();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read profiles from " + filePath, e);
+        }
+    }
+
+    private void writeAll(Map<String, PersonalProfile> map) {
+        try {
+            Files.writeString(filePath, gson.toJson(map, mapType), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write profiles to " + filePath, e);
+        }
+    }
+
+}

--- a/src/main/java/data_access/JsonUserRecordDataAccessObject.java
+++ b/src/main/java/data_access/JsonUserRecordDataAccessObject.java
@@ -1,0 +1,109 @@
+package data_access;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import entity.CommonLearnRecord;          // ← 具体实现类
+import entity.LearnRecord;
+import use_case.finish_checkin.UserSaveRecordDataAccessInterface;
+import use_case.rank.RankUserDataAccessInterface;
+import use_case.gateway.UserRecordDataAccessInterface;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+/**
+ * Persist user learning records in JSON using Gson.
+ * File location: E:\LexiGOv1.1\data\learn_record.json
+ */
+public class JsonUserRecordDataAccessObject
+        implements UserRecordDataAccessInterface, UserSaveRecordDataAccessInterface, RankUserDataAccessInterface {
+
+    /* -------- 文件位置 -------- */
+    private static final Path path = Paths.get("resources", "data", "learn_record.json");
+
+    /* -------- Gson 配置 -------- */
+    private static final DateTimeFormatter ISO = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private final Gson gson;
+
+    /** Map<username, List<CommonLearnRecord>> */
+    private final Type mapType =
+            new TypeToken<Map<String, List<CommonLearnRecord>>>() {}.getType();
+
+    private final Map<String, List<CommonLearnRecord>> cache;
+
+    public JsonUserRecordDataAccessObject() {
+        gson = new GsonBuilder()
+                .registerTypeAdapter(LocalDateTime.class,
+                        (com.google.gson.JsonSerializer<LocalDateTime>)
+                                (src, t, ctx) -> ctx.serialize(src.format(ISO)))
+                .registerTypeAdapter(LocalDateTime.class,
+                        (com.google.gson.JsonDeserializer<LocalDateTime>)
+                                (json, t, ctx) -> LocalDateTime.parse(json.getAsString(), ISO))
+                .setPrettyPrinting()
+                .create();
+
+        cache = loadFromDisk();
+    }
+
+    @Override
+    public synchronized List<LearnRecord> get(String username) {
+        return new ArrayList<>(cache.getOrDefault(username, List.of()));
+    }
+
+    @Override
+    public synchronized Map<String, List<LearnRecord>> getAllUsers() {
+        Map<String, List<LearnRecord>> result = new HashMap<>();
+
+        cache.forEach((user, list) -> {
+
+            result.put(user, new ArrayList<>(list));
+        });
+
+        return Collections.unmodifiableMap(result);
+    }
+
+    @Override
+    public synchronized void save(LearnRecord rec) {
+        Objects.requireNonNull(rec.getUsername(), "username must not be null");
+
+        CommonLearnRecord record = (CommonLearnRecord) rec;
+
+        cache.computeIfAbsent(record.getUsername(), k -> new ArrayList<>())
+                .add(record);
+        flush();
+    }
+
+    private Map<String, List<CommonLearnRecord>> loadFromDisk() {
+        try {
+            if (Files.notExists(path)) {
+                Files.createDirectories(path.getParent());
+                Files.writeString(path, "{}", StandardCharsets.UTF_8);
+            }
+
+            String json = Files.readString(path);
+            Map<String, List<CommonLearnRecord>> map =
+                    gson.fromJson(json, mapType);
+            return map != null ? map : new HashMap<>();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read learn_record.json", e);
+        }
+    }
+
+    private void flush() {
+        try {
+            Files.writeString(path, gson.toJson(cache, mapType));
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot write learn_record.json", e);
+        }
+    }
+
+}

--- a/src/main/java/data_access/WordBookDataAccessObject.java
+++ b/src/main/java/data_access/WordBookDataAccessObject.java
@@ -1,0 +1,76 @@
+package data_access;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import entity.CommonWordBook;
+import entity.WordBook;
+import use_case.start_checkin.WordBookAccessInterface;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+
+/**
+ * Read a local JSON file like:
+ * {
+ *   "TOEIC-800": ["550e8400-e29b-41d4-a716-446655440000", ...],
+ *   "GRE-High":  ["3fa85f64-5717-4562-b3fc-2c963f66afa6"]
+ * }
+ * and convert it to a CommonWordBook.
+ */
+public class WordBookDataAccessObject implements WordBookAccessInterface {
+    private static Path FILE;
+    static {
+        try {
+            URL resource = WordBookDataAccessObject.class
+                    .getClassLoader()
+                    .getResource("data/wordbook.json");
+
+            if (resource == null) {
+                throw new IllegalStateException("wordbook.json not found in resources");
+            }
+
+            FILE = Paths.get(resource.toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** simple in‑memory cache */
+    private Map<String, List<UUID>> cache;
+
+    public WordBookDataAccessObject() {
+        this.cache = load();
+    }
+
+    @Override
+    public WordBook get() {
+        if (cache.isEmpty())
+            throw new IllegalStateException("No word book found in JSON file");
+        // choose the first entry as default; or inject a book name in the ctor
+        Map.Entry<String, List<UUID>> entry = cache.entrySet().iterator().next();
+        return new CommonWordBook(entry.getKey(), entry.getValue());
+    }
+
+    private Map<String, List<UUID>> load() {
+        try {
+            if (Files.notExists(FILE)) {
+                Files.createDirectories(FILE.getParent());
+                Files.writeString(FILE, "{}");
+            }
+            return mapper.readValue(Files.newInputStream(FILE),
+                    new TypeReference<Map<String, List<UUID>>>() {});
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read wordbook.json", e);
+        }
+    }
+}

--- a/src/main/java/data_access/WordDataAccessObject.java
+++ b/src/main/java/data_access/WordDataAccessObject.java
@@ -1,0 +1,72 @@
+package data_access;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import use_case.start_checkin.WordDataAccessInterface;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Read a JSON file like:
+ * {
+ *   "550e8400-e29b-41d4-a716-446655440000": "apple",
+ *   "3fa85f64-5717-4562-b3fc-2c963f66afa6": "table"
+ * }
+ * and expose word text lookup by UUID.
+ */
+public class WordDataAccessObject implements WordDataAccessInterface {
+
+    private static Path FILE;
+
+    static {
+        try {
+            URL resource = WordBookDataAccessObject.class.getClassLoader()
+                    .getResource("data/words.json");
+            if (resource == null) {
+                throw new IllegalStateException("words.json not found in resources");
+            }
+            FILE = Paths.get(resource.toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** cached whole dictionary: UUID → word */
+    private final Map<UUID, String> dictionary;
+
+    public WordDataAccessObject() {
+        this.dictionary = load();
+    }
+
+    @Override
+    public String get(UUID wordId) {
+        String word = dictionary.get(wordId);
+        if (word == null) {
+            throw new IllegalArgumentException("WordId not found: " + wordId);
+        }
+        return word;
+    }
+
+    private Map<UUID, String> load() {
+        try {
+            if (Files.notExists(FILE)) {
+                Files.createDirectories(FILE.getParent());
+                Files.writeString(FILE, "{}");
+            }
+            return mapper.readValue(
+                    Files.newInputStream(FILE),
+                    new TypeReference<Map<UUID, String>>() {});
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read words.json", e);
+        }
+    }
+}

--- a/src/main/java/infrastructure/LearnWordsGenerator.java
+++ b/src/main/java/infrastructure/LearnWordsGenerator.java
@@ -1,0 +1,34 @@
+package infrastructure;
+
+import entity.LearnRecord;
+import entity.WordBook;
+import use_case.start_checkin.LearnDeckGenerator;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class LearnWordsGenerator implements LearnDeckGenerator {
+
+    @Override
+    public List<UUID> generate(WordBook wordBook, List<LearnRecord> history, String length) {
+        List<UUID> uuidsTotal = wordBook.getWordIds();
+        List<UUID> uuidsLearned = new ArrayList<>();
+        for (LearnRecord record : history) {
+            for (UUID id : record.getLearnedWordIds()) {
+                uuidsLearned.add(id);
+            }
+        }
+        Set<UUID> learnedSet = new HashSet<>(uuidsLearned);
+
+        List<UUID> candidates = uuidsTotal.stream()
+                .filter(id -> !learnedSet.contains(id))
+                .collect(Collectors.toList());
+
+        if (candidates.size() <= Integer.parseInt(length)) {
+            return candidates;
+        }
+
+        Collections.shuffle(candidates);
+        return candidates.subList(0, Integer.parseInt(length));
+    }
+}

--- a/src/main/java/interface_adapter/rank/RankController.java
+++ b/src/main/java/interface_adapter/rank/RankController.java
@@ -1,0 +1,21 @@
+package interface_adapter.rank;
+
+import use_case.rank.RankInputBoundary;
+import use_case.rank.RankInputData;
+
+public class RankController {
+    private RankInputBoundary rankInteractor;
+
+    public RankController(RankInputBoundary rankInteractor) {
+        this.rankInteractor = rankInteractor;
+    }
+
+    /**
+     * Executes the Logout Use Case.
+     * @param username the username of the user logging in
+     */
+    public void execute(String username) {
+        final RankInputData rankInputData = new RankInputData(username);
+        this.rankInteractor.execute(rankInputData);
+    }
+}

--- a/src/main/java/interface_adapter/rank/RankPresenter.java
+++ b/src/main/java/interface_adapter/rank/RankPresenter.java
@@ -1,0 +1,20 @@
+package interface_adapter.rank;
+
+import use_case.rank.RankOutputBoundary;
+import use_case.rank.RankOutputData;
+
+
+public class RankPresenter implements RankOutputBoundary {
+    private final RankViewModel vm;
+    public RankPresenter(RankViewModel vm){ this.vm = vm; }
+
+    public void prepareSuccessView(RankOutputData out) {
+
+        RankState state = vm.getState();
+        state.setCurrentUser(out.currentUser());
+        state.setLeaderboard(out.leaderboard());
+        state.setPosition(out.myPosition());
+        vm.setState(state);
+        vm.firePropertyChanged();
+    }
+}

--- a/src/main/java/interface_adapter/rank/RankState.java
+++ b/src/main/java/interface_adapter/rank/RankState.java
@@ -1,0 +1,34 @@
+package interface_adapter.rank;
+
+import use_case.rank.RankEntryData;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RankState {
+
+    private List<RankEntryData> leaderboard = Collections.synchronizedList(new ArrayList<>());
+    private String currentUser = "";
+    private int position = 0;
+
+    /* ---------- Getter ---------- */
+    public List<RankEntryData> getLeaderboard() { return leaderboard; }
+
+    public String getCurrentUser() { return currentUser; }
+
+    public int getPosition() { return position; }
+
+    public void setLeaderboard(List<RankEntryData> leaderboard) {
+        this.leaderboard = leaderboard;
+    }
+
+    public void setCurrentUser(String currentUser) {
+        this.currentUser = currentUser;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+}

--- a/src/main/java/interface_adapter/rank/RankViewModel.java
+++ b/src/main/java/interface_adapter/rank/RankViewModel.java
@@ -1,0 +1,11 @@
+package interface_adapter.rank;
+
+import interface_adapter.ViewModel;
+
+public class RankViewModel extends ViewModel<RankState> {
+
+    public RankViewModel() {
+        super("rank");
+        setState(new RankState());
+    }
+}

--- a/src/main/java/interface_adapter/studysession/word_detail/WordDetailController.java
+++ b/src/main/java/interface_adapter/studysession/word_detail/WordDetailController.java
@@ -1,0 +1,24 @@
+package interface_adapter.studysession.word_detail;
+
+import use_case.studysession.word_detail.WordDetailInputBoundary;
+import use_case.studysession.word_detail.WordDetailInputData;
+
+public class WordDetailController {
+    private WordDetailInputBoundary interactor;
+
+    public WordDetailController(WordDetailInputBoundary interactor) {
+        this.interactor = interactor;
+    }
+
+    public void execute(String pagenumber) {
+        interactor.execute(new WordDetailInputData(pagenumber));
+    }
+
+    public void switchTologgedView() {
+
+    }
+
+    public void switchToStudySessionView() {
+        interactor.switchToStudySessionView();
+    }
+}

--- a/src/main/java/interface_adapter/studysession/word_detail/WordDetailPresenter.java
+++ b/src/main/java/interface_adapter/studysession/word_detail/WordDetailPresenter.java
@@ -1,0 +1,44 @@
+package interface_adapter.studysession.word_detail;
+
+import interface_adapter.ViewManagerModel;
+import interface_adapter.studysession.StudySessionViewModel;
+import use_case.studysession.word_detail.WordDetailOutputBoundary;
+import use_case.studysession.word_detail.WordDetailOutputData;
+
+public class WordDetailPresenter implements WordDetailOutputBoundary {
+
+    private final ViewManagerModel viewManagerModel;
+    private final WordDetailViewModel wordDetailViewModel;
+    private final StudySessionViewModel studySessionViewModel;
+
+    public WordDetailPresenter(ViewManagerModel viewManagerModel,
+                               WordDetailViewModel wordDetailViewModel,
+                               StudySessionViewModel studySessionViewModel) {
+        this.viewManagerModel = viewManagerModel;
+        this.wordDetailViewModel = wordDetailViewModel;
+        this.studySessionViewModel = studySessionViewModel;
+    }
+
+    @Override
+    public void prepareSuccessView(WordDetailOutputData out) {
+        WordDetailState state = wordDetailViewModel.getState();
+        state.setExample(out.getExample());
+        state.setTranslation(out.getTranslation());
+        wordDetailViewModel.setState(state);
+        wordDetailViewModel.firePropertyChanged();
+
+        viewManagerModel.setState(wordDetailViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+
+    @Override
+    public void switchTologgedView() {
+
+    }
+
+    @Override
+    public void switchToStudySessionView() {
+        viewManagerModel.setState(studySessionViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+}

--- a/src/main/java/interface_adapter/studysession/word_detail/WordDetailState.java
+++ b/src/main/java/interface_adapter/studysession/word_detail/WordDetailState.java
@@ -1,0 +1,42 @@
+package interface_adapter.studysession.word_detail;
+
+public class WordDetailState {
+
+    private String translation = "";
+    private String username = "";
+    private String example = "";
+
+    public WordDetailState(String translation,
+                           String username,
+                           String example) {
+        this.translation = translation;
+        this.username = username;
+        this.example = example;
+    }
+
+    public WordDetailState() {}
+
+    public String getTranslation() {
+        return translation;
+    }
+
+    public void setTranslation(String translation) {
+        this.translation = translation;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getExample() {
+        return example;
+    }
+
+    public void setExample(String example) {
+        this.example = example;
+    }
+}

--- a/src/main/java/interface_adapter/studysession/word_detail/WordDetailViewModel.java
+++ b/src/main/java/interface_adapter/studysession/word_detail/WordDetailViewModel.java
@@ -1,0 +1,12 @@
+package interface_adapter.studysession.word_detail;
+
+import interface_adapter.ViewModel;
+
+public class WordDetailViewModel extends ViewModel<WordDetailState> {
+    public static final String TITLE_LABEL = "Word detail View";
+
+    public WordDetailViewModel() {
+        super("word detail");
+        setState(new WordDetailState());
+    }
+}

--- a/src/main/java/use_case/rank/RankEntryData.java
+++ b/src/main/java/use_case/rank/RankEntryData.java
@@ -1,0 +1,27 @@
+package use_case.rank;
+
+public class RankEntryData {
+    private int rank;
+
+    private int score;
+    private String username;
+
+    public RankEntryData(int rank, String username, int score) {
+        this.rank = rank;
+        this.username = username;
+        this.score = score;
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    public int getRank() {
+        return rank;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+}

--- a/src/main/java/use_case/rank/RankInputBoundary.java
+++ b/src/main/java/use_case/rank/RankInputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.rank;
+
+public interface RankInputBoundary {
+    void execute(RankInputData rankInputData);
+}

--- a/src/main/java/use_case/rank/RankInputData.java
+++ b/src/main/java/use_case/rank/RankInputData.java
@@ -1,0 +1,13 @@
+package use_case.rank;
+
+public class RankInputData {
+    private String username;
+
+    public RankInputData(String username) {
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/use_case/rank/RankInteractor.java
+++ b/src/main/java/use_case/rank/RankInteractor.java
@@ -1,0 +1,60 @@
+package use_case.rank;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class RankInteractor implements RankInputBoundary {
+
+    private final RankUserDataAccessInterface dao;
+    private final RankOutputBoundary presenter;
+    private static final int RANK_LIMIT = 10;
+
+    public RankInteractor(RankUserDataAccessInterface dao, RankOutputBoundary presenter) {
+        this.dao = dao;
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void execute(RankInputData in) {
+
+        List<Map.Entry<String, Integer>> users = dao.getAllUsers().entrySet()
+                .stream()
+                .map(e -> new AbstractMap.SimpleEntry<>(
+                        e.getKey(),
+                        e.getValue().stream()
+                                .mapToInt(rec -> rec.getLearnedWordIds().size())
+                                .sum()))
+                .sorted((a, b) -> {
+                    int cmp = Integer.compare(b.getValue(), a.getValue());
+                    return (cmp != 0) ? cmp : a.getKey().compareTo(b.getKey());
+                })
+                .collect(Collectors.toList());
+
+        List<RankEntryData> top = new ArrayList<>();
+        int rank       = 0;
+        int prevScore  = Integer.MIN_VALUE;
+        int myPosition = -1;
+
+        for (int i = 0; i < users.size(); i++) {
+            Map.Entry<String, Integer> e = users.get(i);
+
+            if (e.getValue() != prevScore) {
+                rank = i + 1;
+                prevScore = e.getValue();
+            }
+
+            if (rank <= RANK_LIMIT) {
+                top.add(new RankEntryData(rank, e.getKey(), e.getValue()));
+            }
+
+            if (e.getKey().equals(in.getUsername())) {
+                myPosition = rank;
+            }
+
+            if (rank > RANK_LIMIT && myPosition != -1) break;
+        }
+
+        presenter.prepareSuccessView(
+                new RankOutputData(in.getUsername(), top, myPosition));
+    }
+}

--- a/src/main/java/use_case/rank/RankOutputBoundary.java
+++ b/src/main/java/use_case/rank/RankOutputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.rank;
+
+public interface RankOutputBoundary {
+    void prepareSuccessView(RankOutputData rankOutputData);
+}

--- a/src/main/java/use_case/rank/RankOutputData.java
+++ b/src/main/java/use_case/rank/RankOutputData.java
@@ -1,0 +1,23 @@
+package use_case.rank;
+
+import java.util.List;
+
+public class RankOutputData {
+
+
+    private final String currentUser;
+    private final List<RankEntryData> leaderboard;
+    private final int myPosition;
+
+    public RankOutputData(String currentUser,
+                          List<RankEntryData> leaderboard,
+                          int myPosition) {
+        this.currentUser  = currentUser;
+        this.leaderboard  = leaderboard;
+        this.myPosition   = myPosition;
+    }
+
+    public String currentUser()              { return currentUser;  }
+    public List<RankEntryData> leaderboard() { return leaderboard;  }
+    public int myPosition()                  { return myPosition;   }
+}

--- a/src/main/java/use_case/rank/RankUserDataAccessInterface.java
+++ b/src/main/java/use_case/rank/RankUserDataAccessInterface.java
@@ -1,0 +1,13 @@
+package use_case.rank;
+
+import entity.LearnRecord;
+
+import java.util.List;
+import java.util.Map;
+
+public interface RankUserDataAccessInterface {
+    /**
+     * Returns a map of all usernames and their scores.
+     */
+    Map<String, List<LearnRecord>> getAllUsers();
+}

--- a/src/main/java/use_case/studysession/word_detail/WordDetailDataAccessInterface.java
+++ b/src/main/java/use_case/studysession/word_detail/WordDetailDataAccessInterface.java
@@ -1,0 +1,8 @@
+package use_case.studysession.word_detail;
+
+public interface WordDetailDataAccessInterface {
+
+    String getTranslation(int i);
+
+    String getExample(int i);
+}

--- a/src/main/java/use_case/studysession/word_detail/WordDetailInputBoundary.java
+++ b/src/main/java/use_case/studysession/word_detail/WordDetailInputBoundary.java
@@ -1,0 +1,7 @@
+package use_case.studysession.word_detail;
+
+public interface WordDetailInputBoundary {
+    void execute(WordDetailInputData in);
+    void switchTologgedView();
+    void switchToStudySessionView();
+}

--- a/src/main/java/use_case/studysession/word_detail/WordDetailInputData.java
+++ b/src/main/java/use_case/studysession/word_detail/WordDetailInputData.java
@@ -1,0 +1,13 @@
+package use_case.studysession.word_detail;
+
+public class WordDetailInputData {
+    private String currpage;
+
+    public WordDetailInputData(String currpage) {
+        this.currpage = currpage;
+    }
+
+    public String getCurrpage() {
+        return currpage;
+    }
+}

--- a/src/main/java/use_case/studysession/word_detail/WordDetailInteractor.java
+++ b/src/main/java/use_case/studysession/word_detail/WordDetailInteractor.java
@@ -1,0 +1,34 @@
+package use_case.studysession.word_detail;
+
+public class WordDetailInteractor implements WordDetailInputBoundary {
+
+    private final WordDetailOutputBoundary presenter;
+    private final WordDetailDataAccessInterface wordDetailDataAccess;
+
+    public WordDetailInteractor(WordDetailOutputBoundary presenter,
+                                WordDetailDataAccessInterface wordDetailDataAccess) {
+        this.presenter = presenter;
+        this.wordDetailDataAccess = wordDetailDataAccess;
+    }
+
+    @Override
+    public void execute(WordDetailInputData in) {
+        String translation = wordDetailDataAccess.getTranslation(
+                Integer.parseInt(in.getCurrpage()) - 1);
+        String example = wordDetailDataAccess.getExample(
+                Integer.parseInt(in.getCurrpage()) - 1);
+
+        WordDetailOutputData wordDetailOutputData = new WordDetailOutputData(translation, example);
+        presenter.prepareSuccessView(wordDetailOutputData);
+    }
+
+    @Override
+    public void switchTologgedView() {
+
+    }
+
+    @Override
+    public void switchToStudySessionView() {
+        presenter.switchToStudySessionView();
+    }
+}

--- a/src/main/java/use_case/studysession/word_detail/WordDetailOutputBoundary.java
+++ b/src/main/java/use_case/studysession/word_detail/WordDetailOutputBoundary.java
@@ -1,0 +1,7 @@
+package use_case.studysession.word_detail;
+
+public interface WordDetailOutputBoundary {
+    void prepareSuccessView(WordDetailOutputData out);
+    void switchTologgedView();
+    void switchToStudySessionView();
+}

--- a/src/main/java/use_case/studysession/word_detail/WordDetailOutputData.java
+++ b/src/main/java/use_case/studysession/word_detail/WordDetailOutputData.java
@@ -1,0 +1,21 @@
+package use_case.studysession.word_detail;
+
+public class WordDetailOutputData {
+
+    private String translation;
+    private String example;
+
+    public WordDetailOutputData(String translation,
+                                String example) {
+        this.translation = translation;
+        this.example = example;
+    }
+
+    public String getTranslation() {
+        return translation;
+    }
+
+    public String getExample() {
+        return example;
+    }
+}

--- a/src/main/java/view/RankView.java
+++ b/src/main/java/view/RankView.java
@@ -1,0 +1,79 @@
+package view;
+
+import interface_adapter.rank.RankController;
+import interface_adapter.rank.RankState;
+import interface_adapter.rank.RankViewModel;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/** 排行榜页面：监听 RankViewModel 的 "leaderboard" / "currentUser" 属性来刷新。 */
+public class RankView extends JPanel implements PropertyChangeListener {
+
+    /* ── 依赖 ───────────────────────────── */
+    private final RankViewModel vm;
+    private final RankController controller;                     // 可后置注入
+
+    /* ── Swing 组件 ─────────────────────── */
+    private final JLabel title = new JLabel("Leaderboard", SwingConstants.CENTER);
+
+    private final DefaultTableModel tableModel = new DefaultTableModel(
+            new Object[]{"Rank", "Username", "Scores"}, 0) {
+        public boolean isCellEditable(int r, int c) { return false; }
+    };
+    private final JTable table = new JTable(tableModel);
+
+    /* ── 构造 ───────────────────────────── */
+    public RankView(RankViewModel vm, RankController controller) {
+        this.vm = vm;
+        this.controller = controller;          // 允许 null，稍后再注入
+        this.vm.addPropertyChangeListener(this);
+        setLayout(new BorderLayout(10, 10));
+
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 18f));
+        add(title, BorderLayout.NORTH);
+
+        table.setFillsViewportHeight(true);
+        add(new JScrollPane(table), BorderLayout.CENTER);
+
+        JButton refresh = new JButton("Refresh");
+        refresh.addActionListener(e -> {
+            if (this.controller != null) {
+                this.controller.execute(vm.getState().getCurrentUser());   // ★ 统一用 refresh
+            }
+        });
+        add(refresh, BorderLayout.SOUTH);
+    }
+
+    /* ── ViewModel → View 同步 ───────────────────────── */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        // ① 只关心 state 事件
+        if ("state".equals(evt.getPropertyName())) {
+
+            // ② 拿到最新快照
+            RankState s = (RankState) evt.getNewValue();
+
+            // ③ 确保在 Swing EDT 中更新 UI，避免线程问题
+            SwingUtilities.invokeLater(() -> {
+
+                /* ===== 刷新排行榜表格 ===== */
+                tableModel.setRowCount(0);        // 清空旧行
+                s.getLeaderboard().forEach(e ->
+                        tableModel.addRow(new Object[]{
+                                e.getRank(),
+                                e.getUsername(),
+                                e.getScore()   // ★ 直接使用 DTO 字段
+                        })
+                );
+
+                /* ===== 更新标题栏 ===== */
+                title.setText("Leaderboard — " + s.getCurrentUser());
+            });
+        }
+    }
+
+}

--- a/src/main/java/view/WordDetailView.java
+++ b/src/main/java/view/WordDetailView.java
@@ -1,0 +1,79 @@
+package view;
+
+
+import interface_adapter.studysession.word_detail.WordDetailController;
+import interface_adapter.studysession.word_detail.WordDetailState;
+import interface_adapter.studysession.word_detail.WordDetailViewModel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * 仅显示翻译和例句的单词详情视图（不再展示原单词本身）。
+ */
+public class WordDetailView extends JPanel implements PropertyChangeListener {
+
+    /* --- 常量 --- */
+    private static final String VIEW_NAME = "word detail";
+
+    /* --- MVC 成员 --- */
+    private final WordDetailViewModel viewModel;
+    private WordDetailController     controller;
+
+    /* --- UI 组件 --- */
+    private final JLabel transLabel   = new JLabel("Translation", SwingConstants.CENTER);
+    private final JLabel exampleLabel = new JLabel("Example",     SwingConstants.CENTER);
+    private final JButton flipBack    = new JButton("Flip back");
+
+    /* ------------------------------------------------------------ */
+
+    public WordDetailView(WordDetailViewModel vm) {
+        this.viewModel = vm;
+        vm.addPropertyChangeListener(this);
+
+        /* ---------- 字体 ---------- */
+        transLabel.setFont(transLabel.getFont().deriveFont(Font.PLAIN, 18f));
+        exampleLabel.setFont(exampleLabel.getFont().deriveFont(Font.ITALIC, 16f));
+
+        /* ---------- 布局 ---------- */
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        add(Box.createVerticalStrut(30));  // 上边距
+        add(transLabel);
+        add(Box.createVerticalStrut(15));
+        add(exampleLabel);
+        add(Box.createVerticalStrut(20));
+
+        // 按钮区域
+        JPanel nav = new JPanel();
+        nav.add(flipBack);
+        add(nav);
+
+        /* ---------- 事件 ---------- */
+        flipBack.addActionListener(e -> {
+            if (controller != null) controller.switchToStudySessionView();
+        });
+    }
+
+    /* ================= PropertyChangeListener ================= */
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if ("state".equals(evt.getPropertyName())) {
+            WordDetailState s = (WordDetailState) evt.getNewValue();
+            transLabel.setText(s.getTranslation());
+            exampleLabel.setText("<html><body style='text-align:center'>" +
+                    s.getExample() + "</body></html>");
+        }
+    }
+
+    /* ================= 公共方法 ================= */
+
+    public String getViewName() { return VIEW_NAME; }
+
+    public void setWordDetailController(WordDetailController c) {
+        this.controller = c;
+    }
+}
+


### PR DESCRIPTION
## Highlights (mapped to Clean Architecture layers)

| Layer | Key Additions |
|-------|---------------|
| **Framework/Drivers – Persistence** | **+ 6 DAO classes**<br>• `JsonUserDataAccessObject`, `JsonUserProfileDAO`, `JsonUserRecordDataAccessObject` (single‑file JSON)<br>• `WordDataAccessObject`, `WordBookDataAccessObject` (deck & word stores)<br>• `InMemoryDeckDataAccessObejct` for in‑memory tests |
| **Framework/Drivers – Utilities** | + `LearnWordsGenerator` — auto‑generates starter decks on first launch |
| **Interface Adapters – Rank** | Controller / Presenter / State / ViewModel / **`RankView`** wired around **`RankInteractor`** |
| **Interface Adapters – Word Detail** | Controller / Presenter / State / ViewModel / **`WordDetailView`** wired around **`WordDetailInteractor`** |
| **Use‑Case layer** | • `RankInteractor` and DTO set<br>• `WordDetailInteractor` and DTO set |
| **Outer Composition** | Updated **`AppBuilder`** & **`Main`** to register new DAOs, interactors, and screens (dependency arrows still point inward) |
