### PR TITLE
feat(rank): decouple leaderboard & scoring logic

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -238,7 +238,7 @@ public class AppBuilder {
 
         rankViewModel = new RankViewModel();
         final RankOutputBoundary rankPresenter = new RankPresenter(rankViewModel);
-        final RankInputBoundary rankInteractor = new RankInteractor(userRecordDataAccessObject, rankPresenter);
+        final RankInputBoundary rankInteractor = new RankInteractor(userRecordDataAccessObject, rankPresenter, 10);
         final RankController rankController = new RankController(rankInteractor);
         rankView = new RankView(rankViewModel, rankController);
 

--- a/src/main/java/interface_adapter/rank/RankState.java
+++ b/src/main/java/interface_adapter/rank/RankState.java
@@ -1,6 +1,6 @@
 package interface_adapter.rank;
 
-import use_case.rank.RankEntryData;
+import use_case.rank.UserScore;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -8,18 +8,18 @@ import java.util.List;
 
 public class RankState {
 
-    private List<RankEntryData> leaderboard = Collections.synchronizedList(new ArrayList<>());
+    private List<UserScore> leaderboard = Collections.synchronizedList(new ArrayList<>());
     private String currentUser = "";
     private int position = 0;
 
     /* ---------- Getter ---------- */
-    public List<RankEntryData> getLeaderboard() { return leaderboard; }
+    public List<UserScore> getLeaderboard() { return leaderboard; }
 
     public String getCurrentUser() { return currentUser; }
 
     public int getPosition() { return position; }
 
-    public void setLeaderboard(List<RankEntryData> leaderboard) {
+    public void setLeaderboard(List<UserScore> leaderboard) {
         this.leaderboard = leaderboard;
     }
 

--- a/src/main/java/use_case/rank/DefaultLeaderboardSelector.java
+++ b/src/main/java/use_case/rank/DefaultLeaderboardSelector.java
@@ -1,0 +1,36 @@
+package use_case.rank;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultLeaderboardSelector implements LeaderboardSelector {
+
+    @Override
+    public LeaderboardStat getSortedRank(List<Map.Entry<String, Integer>> sortedRank, String username, int limit) {
+        List<UserScore> top = new ArrayList<>();
+        int rank       = 0;
+        int prevScore  = Integer.MIN_VALUE;
+        int myPosition = -1;
+
+        for (int i = 0; i < sortedRank.size(); i++) {
+            Map.Entry<String, Integer> e = sortedRank.get(i);
+
+            if (e.getValue() != prevScore) {
+                rank = i + 1;
+                prevScore = e.getValue();
+            }
+
+            if (rank <= limit) {
+                top.add(new UserScore(rank, e.getKey(), e.getValue()));
+            }
+
+            if (e.getKey().equals(username)) {
+                myPosition = rank;
+            }
+
+            if (rank > limit && myPosition != -1) break;
+        }
+        return new LeaderboardStat(myPosition,top);
+    }
+}

--- a/src/main/java/use_case/rank/DefaultScoreSort.java
+++ b/src/main/java/use_case/rank/DefaultScoreSort.java
@@ -1,0 +1,26 @@
+package use_case.rank;
+
+import entity.LearnRecord;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DefaultScoreSort implements ScoreSortService {
+    @Override
+    public List<Map.Entry<String, Integer>> getSortedRank(Map<String, List<LearnRecord>> input) {
+        return input.entrySet()
+                .stream()
+                .map(e -> new AbstractMap.SimpleEntry<>(
+                        e.getKey(),
+                        e.getValue().stream()
+                                .mapToInt(rec -> rec.getLearnedWordIds().size())
+                                .sum()))
+                .sorted((a, b) -> {
+                    int cmp = Integer.compare(b.getValue(), a.getValue());
+                    return (cmp != 0) ? cmp : a.getKey().compareTo(b.getKey());
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/use_case/rank/LeaderboardSelector.java
+++ b/src/main/java/use_case/rank/LeaderboardSelector.java
@@ -1,0 +1,8 @@
+package use_case.rank;
+
+import java.util.List;
+import java.util.Map;
+
+public interface LeaderboardSelector {
+    LeaderboardStat getSortedRank(List<Map.Entry<String, Integer>> sortedRank, String username, int limit);
+}

--- a/src/main/java/use_case/rank/LeaderboardStat.java
+++ b/src/main/java/use_case/rank/LeaderboardStat.java
@@ -1,0 +1,21 @@
+package use_case.rank;
+
+import java.util.List;
+
+public class LeaderboardStat {
+    private final int position;
+    private final List<UserScore> ranks;
+
+    public LeaderboardStat(int position, List<UserScore> ranks) {
+        this.position = position;
+        this.ranks = ranks;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public List<UserScore> getRanks() {
+        return ranks;
+    }
+}

--- a/src/main/java/use_case/rank/RankInputData.java
+++ b/src/main/java/use_case/rank/RankInputData.java
@@ -1,7 +1,7 @@
 package use_case.rank;
 
 public class RankInputData {
-    private String username;
+    private final String username;
 
     public RankInputData(String username) {
         this.username = username;

--- a/src/main/java/use_case/rank/RankInteractor.java
+++ b/src/main/java/use_case/rank/RankInteractor.java
@@ -1,60 +1,35 @@
 package use_case.rank;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Map;
 
 public class RankInteractor implements RankInputBoundary {
 
     private final RankUserDataAccessInterface dao;
     private final RankOutputBoundary presenter;
-    private static final int RANK_LIMIT = 10;
+    private final LeaderboardSelector leaderboardSelector;
+    private final ScoreSortService scoreSortService;
+    private final int limit;
 
-    public RankInteractor(RankUserDataAccessInterface dao, RankOutputBoundary presenter) {
+    public RankInteractor(RankUserDataAccessInterface dao, RankOutputBoundary presenter, int limit) {
+        this(dao, presenter, new DefaultLeaderboardSelector(), new DefaultScoreSort(), limit);
+    }
+
+    public RankInteractor(RankUserDataAccessInterface dao, RankOutputBoundary presenter, LeaderboardSelector leaderboardSelector, ScoreSortService scoreSortService, int limit) {
         this.dao = dao;
         this.presenter = presenter;
+        this.leaderboardSelector = leaderboardSelector;
+        this.scoreSortService = scoreSortService;
+        this.limit = limit;
     }
 
     @Override
     public void execute(RankInputData in) {
+        List<Map.Entry<String, Integer>> users = scoreSortService.getSortedRank(dao.getAllUsers());
 
-        List<Map.Entry<String, Integer>> users = dao.getAllUsers().entrySet()
-                .stream()
-                .map(e -> new AbstractMap.SimpleEntry<>(
-                        e.getKey(),
-                        e.getValue().stream()
-                                .mapToInt(rec -> rec.getLearnedWordIds().size())
-                                .sum()))
-                .sorted((a, b) -> {
-                    int cmp = Integer.compare(b.getValue(), a.getValue());
-                    return (cmp != 0) ? cmp : a.getKey().compareTo(b.getKey());
-                })
-                .collect(Collectors.toList());
-
-        List<RankEntryData> top = new ArrayList<>();
-        int rank       = 0;
-        int prevScore  = Integer.MIN_VALUE;
-        int myPosition = -1;
-
-        for (int i = 0; i < users.size(); i++) {
-            Map.Entry<String, Integer> e = users.get(i);
-
-            if (e.getValue() != prevScore) {
-                rank = i + 1;
-                prevScore = e.getValue();
-            }
-
-            if (rank <= RANK_LIMIT) {
-                top.add(new RankEntryData(rank, e.getKey(), e.getValue()));
-            }
-
-            if (e.getKey().equals(in.getUsername())) {
-                myPosition = rank;
-            }
-
-            if (rank > RANK_LIMIT && myPosition != -1) break;
-        }
+        LeaderboardStat leaderboardStat = leaderboardSelector.getSortedRank(users, in.getUsername(), limit);
 
         presenter.prepareSuccessView(
-                new RankOutputData(in.getUsername(), top, myPosition));
+                new RankOutputData(in.getUsername(), leaderboardStat.getRanks(), leaderboardStat.getPosition()));
     }
 }

--- a/src/main/java/use_case/rank/RankOutputData.java
+++ b/src/main/java/use_case/rank/RankOutputData.java
@@ -4,13 +4,12 @@ import java.util.List;
 
 public class RankOutputData {
 
-
     private final String currentUser;
-    private final List<RankEntryData> leaderboard;
+    private final List<UserScore> leaderboard;
     private final int myPosition;
 
     public RankOutputData(String currentUser,
-                          List<RankEntryData> leaderboard,
+                          List<UserScore> leaderboard,
                           int myPosition) {
         this.currentUser  = currentUser;
         this.leaderboard  = leaderboard;
@@ -18,6 +17,6 @@ public class RankOutputData {
     }
 
     public String currentUser()              { return currentUser;  }
-    public List<RankEntryData> leaderboard() { return leaderboard;  }
+    public List<UserScore> leaderboard() { return leaderboard;  }
     public int myPosition()                  { return myPosition;   }
 }

--- a/src/main/java/use_case/rank/ScoreSortService.java
+++ b/src/main/java/use_case/rank/ScoreSortService.java
@@ -1,0 +1,10 @@
+package use_case.rank;
+
+import entity.LearnRecord;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ScoreSortService {
+    List<Map.Entry<String, Integer>> getSortedRank(Map<String, List<LearnRecord>> input);
+}

--- a/src/main/java/use_case/rank/UserScore.java
+++ b/src/main/java/use_case/rank/UserScore.java
@@ -1,12 +1,11 @@
 package use_case.rank;
 
-public class RankEntryData {
-    private int rank;
+public class UserScore {
+    private final int rank;
+    private final int score;
+    private final String username;
 
-    private int score;
-    private String username;
-
-    public RankEntryData(int rank, String username, int score) {
+    public UserScore(int rank, String username, int score) {
         this.rank = rank;
         this.username = username;
         this.score = score;

--- a/src/test/java/use_case/rank/RankInteractorTest.java
+++ b/src/test/java/use_case/rank/RankInteractorTest.java
@@ -1,0 +1,4 @@
+package use_case.rank;
+
+public class RankInteractorTest {
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p><strong>Pull Request Description</strong></p>
<h3>✨ What’s new</h3>
<ul>
<li>
<p><strong>Introduced strategy interfaces</strong></p>
<ul>
<li>
<p><code inline="">LeaderboardSelector</code> – contract for choosing which leaderboard to display</p>
</li>
<li>
<p><code inline="">ScoreSortService</code> – contract for ordering user scores</p>
</li>
</ul>
</li>
<li>
<p><strong>Default implementations</strong></p>
<ul>
<li>
<p><code inline="">DefaultLeaderboardSelector</code> – selects leaderboard by study-streak length</p>
</li>
<li>
<p><code inline="">DefaultScoreSort</code> – sorts scores in descending order with stable tie-breaks</p>
</li>
</ul>
</li>
<li>
<p><strong>Statistics DTO</strong></p>
<ul>
<li>
<p><code inline="">LeaderboardStat</code> aggregates leaderboard metadata for presentation</p>
</li>
</ul>
</li>
</ul>
<h3>🔧 Refactors</h3>

Area | Change
-- | --
AppBuilder | Registers new services and injects them into RankInteractor
RankInteractor | Delegates leaderboard choice and sorting to the new services
RankState, RankInputData, RankOutputData | Updated fields / constructors to support stats payload
UserScore | Renamed from RankEntryData for clearer semantics

</body></html><!--EndFragment-->
</body>
</html>