### PR TITLE
Refactor: use builder design to build up processor chain

### DIFF
--- a/src/main/java/use_case/signup/SignUpProcessor.java
+++ b/src/main/java/use_case/signup/SignUpProcessor.java
@@ -4,7 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import use_case.signup.validation.*;
+import use_case.signup.validation.PasswordMatchProcessor;
+import use_case.signup.validation.PasswordStrengthProcessor;
+import use_case.signup.validation.Processor;
+import use_case.signup.validation.ProcessorOutput;
+import use_case.signup.validation.UsernameNotExistsProcessor;
 
 /**
  * The {@code SignUpProcessor} class acts as the entry point to a chain of responsibility
@@ -17,6 +21,13 @@ import use_case.signup.validation.*;
  *
  * <p>This structure improves modularity, testability, and separation of concerns,
  * and supports the Open/Closed Principle for adding future validation rules.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * Pattern passwordPattern = Pattern.compile("^(?=.*[A-Z])(?=.*\\d).{8,}$");
+ * SignUpProcessor processor = new SignUpProcessor(userDao, passwordPattern);
+ * ProcessorOutput result = processor.signUpProcessor("john_doe", "Secret123", "Secret123");
+ * }</pre>
  *
  * @author [Your Name]
  */
@@ -32,17 +43,19 @@ public class SignUpProcessor {
      * @param passwordRule  the compiled regular expression pattern defining password rules
      */
     public SignUpProcessor(SignupUserDataAccessInterface dao, Pattern passwordRule) {
-        // for extension, switch the order or adding more processor here
-        Processor chainHead =
-                builder()
-                        .addUserExistsCheck(dao)
-                        .addPasswordCheck()
-                        .addPasswordStrengthCheck(passwordRule)
-                        // .addYourCheck()
-                        .build();
-        this.chain = chainHead;
+        // Build the chain: username uniqueness → password match → password strength
+        this.chain = builder()
+                .addUserExistsCheck(dao)
+                .addPasswordCheck()
+                .addPasswordStrengthCheck(passwordRule)
+                .build();
     }
 
+    /**
+     * Returns a new builder for constructing a custom chain of processors.
+     *
+     * @return a {@link Builder} instance
+     */
     public static Builder builder() {
         return new Builder();
     }
@@ -60,43 +73,74 @@ public class SignUpProcessor {
         return chain.process(username, pwd1, pwd2);
     }
 
-    // inner class
-    private static class Builder {
-        private List<Processor> processors =  new ArrayList<>();
+    /**
+     * A builder class for constructing a sequential chain of validation processors.
+     * Each added processor is linked to the next, forming a chain of responsibility.
+     */
+    public static final class Builder {
+        /** Stores processors in the order they should execute. */
+        private List<Processor> processors = new ArrayList<>();
 
+        /**
+         * Adds a check to ensure that the username does not already exist.
+         *
+         * @param dao the data access interface to check username availability
+         * @return this builder instance
+         */
         public Builder addUserExistsCheck(SignupUserDataAccessInterface dao) {
             final UsernameNotExistsProcessor usernameNotExistsProcessor = new UsernameNotExistsProcessor(dao);
             processors.add(usernameNotExistsProcessor);
             return this;
         }
 
+        /**
+         * Adds a check to ensure that the two entered passwords match.
+         *
+         * @return this builder instance
+         */
         public Builder addPasswordCheck() {
             final PasswordMatchProcessor passwordMatchProcessor = new PasswordMatchProcessor();
             processors.add(passwordMatchProcessor);
             return this;
         }
 
+        /**
+         * Adds a password strength validation based on a given regex rule.
+         *
+         * @param passwordRule the compiled regex pattern for password requirements
+         * @return this builder instance
+         */
         public Builder addPasswordStrengthCheck(Pattern passwordRule) {
             final PasswordStrengthProcessor passwordStrengthProcessor = new PasswordStrengthProcessor(passwordRule);
             processors.add(passwordStrengthProcessor);
             return this;
         }
 
+        /**
+         * Adds any custom validation processor to the chain.
+         *
+         * @param otherProcessor the custom processor to add
+         * @return this builder instance
+         */
         public Builder addOtherCheck(Processor otherProcessor) {
             processors.add(otherProcessor);
             return this;
         }
-        // for extension add
-        // public Builder addYourCheck() {.....return this;}
 
+        /**
+         * Builds the processor chain, linking each processor to the next.
+         *
+         * @return the head processor of the chain
+         * @throws IllegalStateException if no processors were added
+         */
         public Processor build() {
             if (processors.isEmpty()) {
                 throw new IllegalStateException("No processors configured.");
             }
-            Processor head = processors.get(0);
+            final Processor head = processors.get(0);
             Processor prev = head;
             for (int i = 1; i < processors.size(); i++) {
-                Processor cur = processors.get(i);
+                final Processor cur = processors.get(i);
                 prev.setNext(cur);
                 prev = cur;
             }

--- a/src/main/java/use_case/signup/security/SignupSecurityInteractor.java
+++ b/src/main/java/use_case/signup/security/SignupSecurityInteractor.java
@@ -41,6 +41,8 @@ public class SignupSecurityInteractor implements SignupSecurityInputBoundary {
         final ProcessorOutput output = processor.signUpProcessor(username, password, repeatPassword);
 
         if (!output.isSuccess()) {
+            // add security checks here, like a processor
+            // e.g output = processorSecurity.process(securityQuestion, securityAnswer), the same design.
             userPresenter.prepareFailView(output.getErrorMessage());
         }
         else {

--- a/src/test/java/use_case/signup/SignUpProcessorBuilderTest.java
+++ b/src/test/java/use_case/signup/SignUpProcessorBuilderTest.java
@@ -1,0 +1,39 @@
+package use_case.signup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mockito;
+import use_case.signup.validation.Processor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SignUpProcessorBuilderTest {
+
+    @Test
+    void build_shouldThrowException_whenNoProcessorsConfigured() {
+        // Arrange
+        SignUpProcessor.Builder builder = SignUpProcessor.builder();
+
+        // Act
+        Executable action = builder::build;
+
+        // Assert
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class, action);
+        assertEquals("No processors configured.", exception.getMessage());
+    }
+
+    @Test
+    void addOtherCheck_shouldAddProcessorSuccessfully() {
+        // Arrange
+        SignUpProcessor.Builder builder = SignUpProcessor.builder();
+        Processor mockProcessor = Mockito.mock(Processor.class);
+
+        // Act
+        builder.addOtherCheck(mockProcessor);
+        Processor chainHead = builder.build();
+
+        // Assert
+        assertSame(mockProcessor, chainHead, "The head of chain should be the same as the added processor");
+    }
+}


### PR DESCRIPTION
#82 
@yunzhaol @Godoftitan @HeyuanZ621 @Y0m1ya 
Inner builder added for sign up validation chain. Now we can use this code example to build up
comparison:
After:
<img width="740" height="284" alt="image" src="https://github.com/user-attachments/assets/ad5a495a-1ca9-4255-8ca0-1c59151864d4" />
Before:
<img width="1190" height="351" alt="image" src="https://github.com/user-attachments/assets/ff7022ff-430f-41ba-9993-bb6e82b4ad52" />
Please review my work to ensure they are correct. :)
